### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/kitsune/access/__init__.py
+++ b/kitsune/access/__init__.py
@@ -12,8 +12,8 @@ def has_perm_or_owns(user, perm, obj, perm_obj,
     if user.is_anonymous():
         return False
 
-    if hasattr(obj, '%s_id' % field_name):
-        if getattr(obj, '%s_id' % field_name) == user.pk:
+    if hasattr(obj, '{0!s}_id'.format(field_name)):
+        if getattr(obj, '{0!s}_id'.format(field_name)) == user.pk:
             return True
     elif user == getattr(obj, field_name):
         return True

--- a/kitsune/access/decorators.py
+++ b/kitsune/access/decorators.py
@@ -36,7 +36,7 @@ def user_access_decorator(redirect_func, redirect_url_func, deny_func=None,
                 # Redirect back here afterwards?
                 if redirect_field:
                     path = urlquote(request.get_full_path())
-                    redirect_url = '%s?%s=%s' % (
+                    redirect_url = '{0!s}?{1!s}={2!s}'.format(
                         redirect_url, redirect_field, path)
 
                 return HttpResponseRedirect(redirect_url)
@@ -142,14 +142,14 @@ def _resolve_lookup((model, lookup, arg_name), view_kwargs):
     """
     value = view_kwargs.get(arg_name)
     if value is None:
-        raise ValueError("Expected kwarg '%s' not found." % arg_name)
+        raise ValueError("Expected kwarg '{0!s}' not found.".format(arg_name))
     if isinstance(model, basestring):
         model_class = get_model(*model.split('.'))
     else:
         model_class = model
     if model_class is None:
-        raise ValueError("The given argument '%s' is not a valid model." %
-                         model)
+        raise ValueError("The given argument '{0!s}' is not a valid model.".format(
+                         model))
     if inspect.isclass(model_class) and not issubclass(model_class, Model):
-        raise ValueError("The argument '%s' needs to be a model." % model)
+        raise ValueError("The argument '{0!s}' needs to be a model.".format(model))
     return get_object_or_404(model_class, **{lookup: value})

--- a/kitsune/announcements/admin.py
+++ b/kitsune/announcements/admin.py
@@ -14,7 +14,7 @@ class AnnouncementAdmin(admin.ModelAdmin):
     def is_visible(self, obj):
         visible = obj.is_visible()
         if visible and obj.show_until:
-            return 'Yes (until %s)' % obj.show_until
+            return 'Yes (until {0!s})'.format(obj.show_until)
         elif visible:
             return 'Yes (always)'
         return ''

--- a/kitsune/customercare/cron.py
+++ b/kitsune/customercare/cron.py
@@ -68,11 +68,11 @@ def collect_tweets():
         try:
             latest_tweet = Tweet.latest()
         except Tweet.DoesNotExist:
-            log.debug('No existing tweets. Retrieving %d tweets from search.' %
-                      settings.CC_TWEETS_PERPAGE)
+            log.debug('No existing tweets. Retrieving {0:d} tweets from search.'.format(
+                      settings.CC_TWEETS_PERPAGE))
         else:
             search_options['since_id'] = latest_tweet.tweet_id
-            log.info('Retrieving tweets with id >= %s' % latest_tweet.tweet_id)
+            log.info('Retrieving tweets with id >= {0!s}'.format(latest_tweet.tweet_id))
 
         # Retrieve Tweets
         results = t.search(**search_options)
@@ -271,6 +271,6 @@ def get_customercare_stats():
         redis.set(key, json.dumps(contributor_stats))
     except RedisError as e:
         statsd.incr('redis.error')
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
 
     return contributor_stats

--- a/kitsune/customercare/views.py
+++ b/kitsune/customercare/views.py
@@ -141,7 +141,7 @@ def landing(request):
         redis = redis_client(name='default')
     except RedisError as e:
         statsd.incr('redis.errror')
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
 
     contributor_stats = redis and redis.get(settings.CC_TOP_CONTRIB_CACHE_KEY)
     if contributor_stats:

--- a/kitsune/dashboards/cron.py
+++ b/kitsune/dashboards/cron.py
@@ -270,8 +270,7 @@ def cache_most_unhelpful_kb_articles():
 
     for entry in sorted_final:
         doc = Document.objects.get(pk=entry[0])
-        redis.rpush(REDIS_KEY, (u'%s::%s::%s::%s::%s::%s::%s' %
-                                (entry[0],  # Document ID
+        redis.rpush(REDIS_KEY, (u'{0!s}::{1!s}::{2!s}::{3!s}::{4!s}::{5!s}::{6!s}'.format(entry[0],  # Document ID
                                  entry[1],  # Total Votes
                                  entry[2],  # Current Percentage
                                  entry[3],  # Difference in Percentage

--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -533,7 +533,7 @@ class Readout(object):
         Return '' if max is None.
 
         """
-        return ' LIMIT %i' % max if max else ''
+        return ' LIMIT {0:d}'.format(max) if max else ''
 
     def get_absolute_url(self, locale, product=None):
         if self.slug in L10N_READOUTS:
@@ -543,7 +543,7 @@ class Readout(object):
             url = reverse('dashboards.contributors_detail',
                           kwargs={'readout_slug': self.slug}, locale=locale)
         else:
-            raise KeyError('This Readout was not found: %s' % self.slug)
+            raise KeyError('This Readout was not found: {0!s}'.format(self.slug))
 
         if product:
             return urlparams(url, product=product.slug)
@@ -691,14 +691,14 @@ class HowToContributeReadout(CategoryReadout):
     title = _lazy(u'How To Contribute')
     slug = 'how-to-contribute'
     details_link_text = _lazy(u'All How To Contribute articles...')
-    where_clause = 'AND engdoc.category=%s ' % HOW_TO_CONTRIBUTE_CATEGORY
+    where_clause = 'AND engdoc.category={0!s} '.format(HOW_TO_CONTRIBUTE_CATEGORY)
 
 
 class AdministrationReadout(CategoryReadout):
     title = _lazy(u'Administration')
     slug = 'administration'
     details_link_text = _lazy(u'All Administration articles...')
-    where_clause = 'AND engdoc.category=%s ' % ADMINISTRATION_CATEGORY
+    where_clause = 'AND engdoc.category={0!s} '.format(ADMINISTRATION_CATEGORY)
 
 
 class MostVisitedTranslationsReadout(MostVisitedDefaultLanguageReadout):
@@ -922,7 +922,7 @@ class UnhelpfulReadout(Readout):
     try:
         hide_readout = redis_client('helpfulvotes').llen(key) == 0
     except RedisError as e:
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
         hide_readout = True
 
     def rows(self, max=None):
@@ -933,7 +933,7 @@ class UnhelpfulReadout(Readout):
             max_get = max or length
             output = redis.lrange(REDIS_KEY, 0, max_get)
         except RedisError as e:
-            log.error('Redis error: %s' % e)
+            log.error('Redis error: {0!s}'.format(e))
             output = []
 
         data = []
@@ -954,8 +954,7 @@ class UnhelpfulReadout(Readout):
             if not doc.count():
                 return None
 
-        helpfulness = Markup('<span title="%+.1f%%">%.1f%%</span>' %
-                             (float(result[3]) * 100, float(result[2]) * 100))
+        helpfulness = Markup('<span title="{0:+.1f}%">{1:.1f}%</span>'.format(float(result[3]) * 100, float(result[2]) * 100))
         return dict(title=result[6].decode('utf-8'),
                     url=reverse('wiki.document_revisions',
                                 args=[unicode(result[5], "utf-8")],

--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -162,8 +162,7 @@ class TopUnhelpfulArticlesCronTests(TestCase):
 
         eq_(1, self.redis.llen(self.REDIS_KEY))
         result = self.redis.lrange(self.REDIS_KEY, 0, 1)
-        eq_(u'%d::%.1f::%.1f::%.1f::%.1f::%s::%s' %
-            (r.document.id, 5.0, 0.4, 0.0, 0.0, r.document.slug,
+        eq_(u'{0:d}::{1:.1f}::{2:.1f}::{3:.1f}::{4:.1f}::{5!s}::{6!s}'.format(r.document.id, 5.0, 0.4, 0.0, 0.0, r.document.slug,
              r.document.title),
             result[0].decode('utf-8'))
 
@@ -201,8 +200,7 @@ class TopUnhelpfulArticlesCronTests(TestCase):
 
         eq_(1, self.redis.llen(self.REDIS_KEY))
         result = self.redis.lrange(self.REDIS_KEY, 0, 1)
-        eq_(u'%d::%.1f::%.1f::%.1f::%.1f::%s::%s' %
-            (r.document.id, 5.0, 0.4, 0.2, 0.0, r.document.slug,
+        eq_(u'{0:d}::{1:.1f}::{2:.1f}::{3:.1f}::{4:.1f}::{5!s}::{6!s}'.format(r.document.id, 5.0, 0.4, 0.2, 0.0, r.document.slug,
              r.document.title),
             result[0].decode('utf-8'))
 
@@ -239,9 +237,9 @@ class TopUnhelpfulArticlesCronTests(TestCase):
 
         eq_(3, self.redis.llen(self.REDIS_KEY))
         result = self.redis.lrange(self.REDIS_KEY, 0, 3)
-        assert '%d::%.1f:' % (r2.document.id, 242.0) in result[0]
-        assert '%d::%.1f:' % (r3.document.id, 122.0) in result[1]
-        assert '%d::%.1f:' % (r.document.id, 102.0) in result[2]
+        assert '{0:d}::{1:.1f}:'.format(r2.document.id, 242.0) in result[0]
+        assert '{0:d}::{1:.1f}:'.format(r3.document.id, 122.0) in result[1]
+        assert '{0:d}::{1:.1f}:'.format(r.document.id, 102.0) in result[2]
 
 
 class L10nMetricsTests(TestCase):

--- a/kitsune/forums/models.py
+++ b/kitsune/forums/models.py
@@ -170,7 +170,7 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
         if page > 1:
             query['page'] = page
         url = reverse('forums.posts', args=[self.forum.slug, self.id])
-        return urlparams(url, hash='post-%s' % self.last_post_id, **query)
+        return urlparams(url, hash='post-{0!s}'.format(self.last_post_id), **query)
 
     def save(self, *args, **kwargs):
         super(Thread, self).save(*args, **kwargs)
@@ -358,7 +358,7 @@ class Post(ModelBase):
             query = {'page': self.page}
 
         url_ = self.thread.get_absolute_url()
-        return urlparams(url_, hash='post-%s' % self.id, **query)
+        return urlparams(url_, hash='post-{0!s}'.format(self.id), **query)
 
     @property
     def content_parsed(self):

--- a/kitsune/forums/tests/test_models.py
+++ b/kitsune/forums/tests/test_models.py
@@ -22,13 +22,13 @@ class ForumModelTestCase(ForumTestCase):
     def test_forum_absolute_url(self):
         f = forum(save=True)
 
-        eq_('/forums/%s' % f.slug,
+        eq_('/forums/{0!s}'.format(f.slug),
             f.get_absolute_url())
 
     def test_thread_absolute_url(self):
         t = thread(save=True)
 
-        eq_('/forums/%s/%s' % (t.forum.slug, t.id),
+        eq_('/forums/{0!s}/{1!s}'.format(t.forum.slug, t.id),
             t.get_absolute_url())
 
     def test_post_absolute_url(self):
@@ -44,12 +44,12 @@ class ForumModelTestCase(ForumTestCase):
         url = reverse('forums.posts',
                       kwargs={'forum_slug': p1.thread.forum.slug,
                               'thread_id': p1.thread.id})
-        eq_(urlparams(url, hash='post-%s' % p1.id), p1.get_absolute_url())
+        eq_(urlparams(url, hash='post-{0!s}'.format(p1.id)), p1.get_absolute_url())
 
         url = reverse('forums.posts',
                       kwargs={'forum_slug': p2.thread.forum.slug,
                               'thread_id': p2.thread.id})
-        exp_ = urlparams(url, hash='post-%s' % p2.id, page=2)
+        exp_ = urlparams(url, hash='post-{0!s}'.format(p2.id), page=2)
         eq_(exp_, p2.get_absolute_url())
 
     def test_post_page(self):
@@ -85,8 +85,8 @@ class ForumModelTestCase(ForumTestCase):
         url = t.get_last_post_url()
         assert f.slug in url
         assert str(t.id) in url
-        assert '#post-%s' % lp.id in url
-        assert 'last=%s' % lp.id in url
+        assert '#post-{0!s}'.format(lp.id) in url
+        assert 'last={0!s}'.format(lp.id) in url
 
     def test_last_post_updated(self):
         # Adding/Deleting the last post in a thread and forum should
@@ -249,7 +249,7 @@ class SaveDateTestCase(ForumTestCase):
         """Assert that two datetime objects are within `range` (a timedelta).
         """
         diff = abs(a - b)
-        assert diff < abs(delta), msg or '%s ~= %s' % (a, b)
+        assert diff < abs(delta), msg or '{0!s} ~= {1!s}'.format(a, b)
 
     def test_save_thread_no_created(self):
         """Saving a new thread should behave as if auto_add_now was set."""

--- a/kitsune/forums/tests/test_templates.py
+++ b/kitsune/forums/tests/test_templates.py
@@ -219,7 +219,7 @@ class ThreadsTemplateTests(ForumTestCase):
         doc = pq(response.content)
         last_post_link = doc('ol.threads div.last-post a:not(.username)')[0]
         href = last_post_link.attrib['href']
-        eq_(href.split('#')[1], 'post-%s' % last.id)
+        eq_(href.split('#')[1], 'post-{0!s}'.format(last.id))
 
     def test_empty_thread_errors(self):
         """Posting an empty thread shows errors."""
@@ -299,7 +299,7 @@ class ThreadsTemplateTests(ForumTestCase):
         f = forum(save=True)
 
         response = get(self.client, 'forums.threads', args=[f.slug])
-        eq_('/forums/%s' % f.slug,
+        eq_('/forums/{0!s}'.format(f.slug),
             pq(response.content)('link[rel="canonical"]')[0].attrib['href'])
 
     def test_show_new_thread(self):
@@ -338,7 +338,7 @@ class ForumsTemplateTests(ForumTestCase):
         doc = pq(response.content)
         last_post_link = doc('ol.forums div.last-post a:not(.username)')[0]
         href = last_post_link.attrib['href']
-        eq_(href.split('#')[1], 'post-%s' % p.id)
+        eq_(href.split('#')[1], 'post-{0!s}'.format(p.id))
 
     def test_restricted_is_invisible(self):
         """Forums with restricted view_in permission shouldn't show up."""

--- a/kitsune/forums/views.py
+++ b/kitsune/forums/views.py
@@ -244,8 +244,7 @@ def lock_thread(request, forum_slug, thread_id):
     forum = get_object_or_404(Forum, slug=forum_slug)
     thread = get_object_or_404(Thread, pk=thread_id, forum=forum)
     thread.is_locked = not thread.is_locked
-    log.info("User %s set is_locked=%s on thread with id=%s " %
-             (request.user, thread.is_locked, thread.id))
+    log.info("User {0!s} set is_locked={1!s} on thread with id={2!s} ".format(request.user, thread.is_locked, thread.id))
     thread.save()
 
     return HttpResponseRedirect(
@@ -265,8 +264,7 @@ def sticky_thread(request, forum_slug, thread_id):
     forum = get_object_or_404(Forum, slug=forum_slug)
     thread = get_object_or_404(Thread, pk=thread_id, forum=forum)
     thread.is_sticky = not thread.is_sticky
-    log.info("User %s set is_sticky=%s on thread with id=%s " %
-             (request.user, thread.is_sticky, thread.id))
+    log.info("User {0!s} set is_sticky={1!s} on thread with id={2!s} ".format(request.user, thread.is_sticky, thread.id))
     thread.save()
 
     return HttpResponseRedirect(
@@ -293,8 +291,7 @@ def edit_thread(request, forum_slug, thread_id):
     form = EditThreadForm(request.POST)
 
     if form.is_valid():
-        log.warning('User %s is editing thread with id=%s' %
-                    (request.user, thread.id))
+        log.warning('User {0!s} is editing thread with id={1!s}'.format(request.user, thread.id))
         thread.title = form.cleaned_data['title']
         thread.save()
 
@@ -319,8 +316,7 @@ def delete_thread(request, forum_slug, thread_id):
             'forum': forum, 'thread': thread})
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting thread with id=%s' %
-                (request.user, thread.id))
+    log.warning('User {0!s} is deleting thread with id={1!s}'.format(request.user, thread.id))
     thread.delete()
 
     statsd.incr('forums.delete_thread')
@@ -354,8 +350,7 @@ def move_thread(request, forum_slug, thread_id):
             has_perm(user, 'forums_forum.thread_move_forum', forum)):
         raise PermissionDenied
 
-    log.warning('User %s is moving thread with id=%s to forum with id=%s' %
-                (user, thread.id, new_forum_id))
+    log.warning('User {0!s} is moving thread with id={1!s} to forum with id={2!s}'.format(user, thread.id, new_forum_id))
     thread.forum = new_forum
     thread.save()
 
@@ -390,8 +385,7 @@ def edit_post(request, forum_slug, thread_id, post_id):
             post.updated = datetime.now()
             post_preview = post
         else:
-            log.warning('User %s is editing post with id=%s' %
-                        (request.user, post.id))
+            log.warning('User {0!s} is editing post with id={1!s}'.format(request.user, post.id))
             post.save()
             return HttpResponseRedirect(post.get_absolute_url())
 
@@ -416,8 +410,7 @@ def delete_post(request, forum_slug, thread_id, post_id):
             'forum': forum, 'thread': thread, 'post': post})
 
     # Handle confirm delete form POST
-    log.warning("User %s is deleting post with id=%s" %
-                (request.user, post.id))
+    log.warning("User {0!s} is deleting post with id={1!s}".format(request.user, post.id))
     post.delete()
 
     statsd.incr('forums.delete_post')

--- a/kitsune/gallery/models.py
+++ b/kitsune/gallery/models.py
@@ -26,7 +26,7 @@ class Media(ModelBase):
         unique_together = (('locale', 'title'), ('is_draft', 'creator'))
 
     def __unicode__(self):
-        return '[%s] %s' % (self.locale, self.title)
+        return '[{0!s}] {1!s}'.format(self.locale, self.title)
 
 
 @auto_delete_files

--- a/kitsune/gallery/tests/__init__.py
+++ b/kitsune/gallery/tests/__init__.py
@@ -12,8 +12,8 @@ def image(file_and_save=True, **kwargs):
     if 'creator' not in kwargs:
         u = user(save=True)
 
-    defaults = {'title': 'Some title %s' % str(datetime.now()),
-                'description': 'Some description %s' % str(datetime.now()),
+    defaults = {'title': 'Some title {0!s}'.format(str(datetime.now())),
+                'description': 'Some description {0!s}'.format(str(datetime.now())),
                 'creator': u}
     defaults.update(kwargs)
 

--- a/kitsune/gallery/utils.py
+++ b/kitsune/gallery/utils.py
@@ -58,11 +58,11 @@ def check_media_permissions(media, user, perm_type):
 
     """
     media_type = media.__class__.__name__.lower()
-    perm_name = 'gallery.%s_%s' % (perm_type, media_type)
+    perm_name = 'gallery.{0!s}_{1!s}'.format(perm_type, media_type)
     if user != media.creator and not user.has_perm(perm_name):
         raise PermissionDenied
 
 
 def get_draft_title(user):
-    return u'Draft for user %s. Created at: %s' % (user.username,
+    return u'Draft for user {0!s}. Created at: {1!s}'.format(user.username,
                                                    datetime.now())

--- a/kitsune/gallery/views.py
+++ b/kitsune/gallery/views.py
@@ -168,8 +168,7 @@ def delete_media(request, media_id, media_type='image'):
             'media_format': media_format})
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting %s with id=%s' %
-                (request.user, media_type, media.id))
+    log.warning('User {0!s} is deleting {1!s} with id={2!s}'.format(request.user, media_type, media.id))
     media.delete()
     # Rebuild KB
     schedule_rebuild_kb()

--- a/kitsune/groups/helpers.py
+++ b/kitsune/groups/helpers.py
@@ -21,7 +21,7 @@ def group_link(group):
     try:
         profile = GroupProfile.objects.get(group=group)
         url = reverse('groups.profile', args=[profile.slug])
-        html = '<a href="%s">%s</a>' % (escape(url), escape(group.name))
+        html = '<a href="{0!s}">{1!s}</a>'.format(escape(url), escape(group.name))
         return Markup(html)
     except GroupProfile.DoesNotExist:
         return group.name

--- a/kitsune/groups/tests/test_views.py
+++ b/kitsune/groups/tests/test_views.py
@@ -172,5 +172,5 @@ class JoinContributorsTests(TestCase):
         eq_(405, r.status_code)
         r = self.client.post(url)
         eq_(302, r.status_code)
-        eq_('http://testserver%s' % next, r['location'])
+        eq_('http://testserver{0!s}'.format(next), r['location'])
         assert self.user.groups.filter(name='Contributors').exists()

--- a/kitsune/inproduct/models.py
+++ b/kitsune/inproduct/models.py
@@ -23,4 +23,4 @@ class Redirect(ModelBase):
             self.locale or '*',
             self.topic or '',
             self.target)
-        return u'%s/%s/%s/%s/%s -> %s' % parts
+        return u'{0!s}/{1!s}/{2!s}/{3!s}/{4!s} -> {5!s}'.format(*parts)

--- a/kitsune/inproduct/tests/test_views.py
+++ b/kitsune/inproduct/tests/test_views.py
@@ -76,7 +76,7 @@ class RedirectTestCase(TestCase):
 
     def _targets(self, urls, querystring):
         for input, output in urls:
-            response = self.client.get(u'/1/%s' % input, follow=True)
+            response = self.client.get(u'/1/{0!s}'.format(input), follow=True)
             if output == 404:
                 eq_(404, response.status_code)
             elif output.startswith('http'):

--- a/kitsune/inproduct/views.py
+++ b/kitsune/inproduct/views.py
@@ -92,13 +92,13 @@ def redirect(request, product, version, platform, locale, topic=None):
             'utm_source': 'inproduct'}
         if hasattr(request, 'eu_build'):
             params['eu'] = 1
-        target = u'/%s/%s' % (locale, destination.target.lstrip('/'))
+        target = u'/{0!s}/{1!s}'.format(locale, destination.target.lstrip('/'))
         target = urlparams(target, **params)
 
         # Switch over to HTTPS if we DEBUG=False and sample is active.
         if not settings.DEBUG and waffle.sample_is_active('inproduct-https'):
             domain = Site.objects.get_current().domain
-            target = 'https://%s%s' % (domain, target)
+            target = 'https://{0!s}{1!s}'.format(domain, target)
 
     # 302 because these can change over time.
     return HttpResponseRedirect(target)

--- a/kitsune/kbforums/models.py
+++ b/kitsune/kbforums/models.py
@@ -147,7 +147,7 @@ class Post(ModelBase):
                        locale=self.thread.document.locale,
                        kwargs={'document_slug': self.thread.document.slug,
                                'thread_id': self.thread.id})
-        return urlparams(url_, hash='post-%s' % self.id, **query)
+        return urlparams(url_, hash='post-{0!s}'.format(self.id), **query)
 
     @property
     def content_parsed(self):

--- a/kitsune/kbforums/tests/test_models.py
+++ b/kitsune/kbforums/tests/test_models.py
@@ -24,7 +24,7 @@ class KBForumModelTestCase(KBForumTestCase):
         url_ = reverse('wiki.discuss.posts',
                        locale=p.thread.document.locale,
                        args=[p.thread.document.slug, p.thread.id])
-        exp_ = urlparams(url_, hash='post-%s' % p.id)
+        exp_ = urlparams(url_, hash='post-{0!s}'.format(p.id))
         eq_(exp_, p.get_absolute_url())
 
     def test_last_post_updated(self):
@@ -76,7 +76,7 @@ class KBSaveDateTestCase(KBForumTestCase):
         Assert that two datetime objects are within `range` (a timedelta).
         """
         diff = abs(a - b)
-        assert diff < abs(delta), msg or '%s ~= %s' % (a, b)
+        assert diff < abs(delta), msg or '{0!s} ~= {1!s}'.format(a, b)
 
     def test_save_thread_no_created(self):
         """Saving a new thread should behave as if auto_add_now was set."""

--- a/kitsune/kbforums/tests/test_templates.py
+++ b/kitsune/kbforums/tests/test_templates.py
@@ -168,7 +168,7 @@ class ThreadsTemplateTests(KBForumTestCase):
         doc = pq(response.content)
         last_post_link = doc('ol.threads div.last-post a:not(.username)')[0]
         href = last_post_link.attrib['href']
-        eq_(href.split('#')[1], 'post-%d' % p2.id)
+        eq_(href.split('#')[1], 'post-{0:d}'.format(p2.id))
 
     def test_empty_thread_errors(self):
         """Posting an empty thread shows errors."""

--- a/kitsune/kbforums/tests/test_views.py
+++ b/kitsune/kbforums/tests/test_views.py
@@ -85,7 +85,7 @@ class ThreadTests(KBForumTestCase):
         def check(url):
             response = get(self.client, url, args=[doc.slug])
             st = response.status_code
-            eq_(404, st, '%s was %s, not 404' % (url, st))
+            eq_(404, st, '{0!s} was {1!s}, not 404'.format(url, st))
         check('wiki.discuss.threads')
         check('wiki.discuss.new_thread')
         check('wiki.discuss.threads.feed')

--- a/kitsune/kbforums/views.py
+++ b/kitsune/kbforums/views.py
@@ -208,8 +208,7 @@ def lock_thread(request, document_slug, thread_id):
     doc = get_document(document_slug, request)
     thread = get_object_or_404(Thread, pk=thread_id, document=doc)
     thread.is_locked = not thread.is_locked
-    log.info("User %s set is_locked=%s on KB thread with id=%s " %
-             (request.user, thread.is_locked, thread.id))
+    log.info("User {0!s} set is_locked={1!s} on KB thread with id={2!s} ".format(request.user, thread.is_locked, thread.id))
     thread.save()
 
     return HttpResponseRedirect(
@@ -223,8 +222,7 @@ def sticky_thread(request, document_slug, thread_id):
     doc = get_document(document_slug, request)
     thread = get_object_or_404(Thread, pk=thread_id, document=doc)
     thread.is_sticky = not thread.is_sticky
-    log.info("User %s set is_sticky=%s on KB thread with id=%s " %
-             (request.user, thread.is_sticky, thread.id))
+    log.info("User {0!s} set is_sticky={1!s} on KB thread with id={2!s} ".format(request.user, thread.is_sticky, thread.id))
     thread.save()
 
     return HttpResponseRedirect(
@@ -250,8 +248,7 @@ def edit_thread(request, document_slug, thread_id):
     form = EditThreadForm(request.POST)
 
     if form.is_valid():
-        log.warning('User %s is editing KB thread with id=%s' %
-                    (request.user, thread.id))
+        log.warning('User {0!s} is editing KB thread with id={1!s}'.format(request.user, thread.id))
         thread.title = form.cleaned_data['title']
         thread.save()
 
@@ -274,8 +271,7 @@ def delete_thread(request, document_slug, thread_id):
             'document': doc, 'thread': thread})
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting KB thread with id=%s' %
-                (request.user, thread.id))
+    log.warning('User {0!s} is deleting KB thread with id={1!s}'.format(request.user, thread.id))
     thread.delete()
 
     statsd.incr('kbforums.delete_thread')
@@ -310,8 +306,7 @@ def edit_post(request, document_slug, thread_id, post_id):
             post.updated = datetime.now()
             post_preview = post
         else:
-            log.warning('User %s is editing KB post with id=%s' %
-                        (request.user, post.id))
+            log.warning('User {0!s} is editing KB post with id={1!s}'.format(request.user, post.id))
             post.save()
             return HttpResponseRedirect(post.get_absolute_url())
 
@@ -334,8 +329,7 @@ def delete_post(request, document_slug, thread_id, post_id):
             'document': doc, 'thread': thread, 'post': post})
 
     # Handle confirm delete form POST
-    log.warning("User %s is deleting KB post with id=%s" %
-                (request.user, post.id))
+    log.warning("User {0!s} is deleting KB post with id={1!s}".format(request.user, post.id))
     post.delete()
 
     statsd.incr('kbforums.delete_post')

--- a/kitsune/kpi/api.py
+++ b/kitsune/kpi/api.py
@@ -27,7 +27,7 @@ class CachedAPIView(APIView):
     def _cache_key(self, request):
         params = []
         for key, value in request.GET.items():
-            params.append("%s=%s" % (key, value))
+            params.append("{0!s}={1!s}".format(key, value))
         return u'{viewname}:{params}'.format(
             viewname=self.__class__.__name__,
             params=u':'.join(sorted(params)))
@@ -56,11 +56,11 @@ class SearchClickthroughMetricList(CachedAPIView):
 
     @property
     def searches_kind(self):
-        return 'search clickthroughs:%s:searches' % self.engine
+        return 'search clickthroughs:{0!s}:searches'.format(self.engine)
 
     @property
     def clicks_kind(self):
-        return 'search clickthroughs:%s:clicks' % self.engine
+        return 'search clickthroughs:{0!s}:clicks'.format(self.engine)
 
     def get_objects(self, request):
         """Return all the ratios.

--- a/kitsune/kpi/models.py
+++ b/kitsune/kpi/models.py
@@ -58,5 +58,5 @@ class Metric(ModelBase):
         unique_together = [('kind', 'start', 'end')]
 
     def __unicode__(self):
-        return '%s (%s thru %s): %s' % (
+        return '{0!s} ({1!s} thru {2!s}): {3!s}'.format(
             self.kind, self.start, self.end, self.value)

--- a/kitsune/kpi/surveygizmo_utils.py
+++ b/kitsune/kpi/surveygizmo_utils.py
@@ -82,7 +82,7 @@ def add_email_to_campaign(survey, email):
                 email=email, user=user, password=password),
             timeout=30)
     except requests.exceptions.Timeout:
-        print 'Timedout adding: %s' % email
+        print 'Timedout adding: {0!s}'.format(email)
 
 
 def get_exit_survey_results(survey, date):

--- a/kitsune/lib/pipeline_compilers.py
+++ b/kitsune/lib/pipeline_compilers.py
@@ -15,7 +15,7 @@ class BrowserifyCompiler(CompilerBase):
         return re.search(r'\.browserify(\.[a-fA-F0-9]+)?\.js$', path) is not None
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s %s %s > %s" % (
+        command = "{0!s} {1!s} {2!s} > {3!s}".format(
             getattr(settings, 'PIPELINE_BROWSERIFY_BINARY', '/usr/bin/env browserify'),
             getattr(settings, 'PIPELINE_BROWSERIFY_ARGUMENTS', ''),
             infile,

--- a/kitsune/messages/models.py
+++ b/kitsune/messages/models.py
@@ -19,7 +19,7 @@ class InboxMessage(ModelBase):
 
     def __unicode__(self):
         s = self.message[0:30]
-        return u'to:%s from:%s %s' % (self.to, self.sender, s)
+        return u'to:{0!s} from:{1!s} {2!s}'.format(self.to, self.sender, s)
 
     @property
     def content_parsed(self):
@@ -38,7 +38,7 @@ class OutboxMessage(ModelBase):
 
     def __unicode__(self):
         to = u', '.join([u.username for u in self.to.all()])
-        return u'from:%s to:%s %s' % (self.sender, to, self.message[0:30])
+        return u'from:{0!s} to:{1!s} {2!s}'.format(self.sender, to, self.message[0:30])
 
     @property
     def content_parsed(self):

--- a/kitsune/messages/tasks.py
+++ b/kitsune/messages/tasks.py
@@ -20,7 +20,7 @@ log = logging.getLogger('k.task')
 def email_private_message(inbox_message_id):
     """Send notification of a new private message."""
     inbox_message = InboxMessage.objects.get(id=inbox_message_id)
-    log.debug('Sending email for user (%s)' % (inbox_message.to,))
+    log.debug('Sending email for user ({0!s})'.format(inbox_message.to))
 
     user = inbox_message.to
 

--- a/kitsune/messages/tests/test_templates.py
+++ b/kitsune/messages/tests/test_templates.py
@@ -65,7 +65,7 @@ class SendMessageTestCase(TestCase):
         for i in range(53):
             self.client.post(
                 reverse('messages.new', locale='en-US'),
-                {'to': self.user2.username, 'message': 'hi there %s' % i})
+                {'to': self.user2.username, 'message': 'hi there {0!s}'.format(i)})
 
         # Verify only 50 are sent.
         eq_(50, OutboxMessage.objects.filter(sender=self.user1).count())

--- a/kitsune/messages/views.py
+++ b/kitsune/messages/views.py
@@ -132,7 +132,7 @@ def bulk_action(request, msgtype='inbox'):
                                                    to=request.user)
             messages.update(read=False)
 
-    return redirect('messages.%s' % msgtype)
+    return redirect('messages.{0!s}'.format(msgtype))
 
 
 @login_required

--- a/kitsune/postcrash/models.py
+++ b/kitsune/postcrash/models.py
@@ -9,7 +9,7 @@ class Signature(ModelBase):
     document = models.ForeignKey(Document)
 
     def __unicode__(self):
-        return u'<%s> %s' % (self.signature, self.document.title)
+        return u'<{0!s}> {1!s}'.format(self.signature, self.document.title)
 
     def get_absolute_url(self):
         doc = self.document.get_absolute_url().lstrip('/')

--- a/kitsune/postcrash/tests/test_views.py
+++ b/kitsune/postcrash/tests/test_views.py
@@ -30,5 +30,5 @@ class ApiTests(TestCase):
         url = urlparams(reverse('postcrash.api'), s=slug)
         response = self.client.get(url)
         eq_(200, response.status_code)
-        eq_('https://example.com/kb/%s' % slug, response.content)
+        eq_('https://example.com/kb/{0!s}'.format(slug), response.content)
         eq_('text/plain', response['content-type'])

--- a/kitsune/postcrash/views.py
+++ b/kitsune/postcrash/views.py
@@ -20,4 +20,4 @@ def api(request):
     host = Site.objects.get_current()
     path = sig.get_absolute_url()
     return HttpResponse(
-        u'https://%s%s' % (host, path), content_type='text/plain')
+        u'https://{0!s}{1!s}'.format(host, path), content_type='text/plain')

--- a/kitsune/products/models.py
+++ b/kitsune/products/models.py
@@ -42,7 +42,7 @@ class Product(ModelBase):
         ordering = ['display_order']
 
     def __unicode__(self):
-        return u'%s' % self.title
+        return u'{0!s}'.format(self.title)
 
     @property
     def image_url(self):
@@ -53,7 +53,7 @@ class Product(ModelBase):
     def sprite_url(self, retina=True):
         fn = 'logo-sprite-2x.png' if retina else 'logo-sprite.png'
         url = os.path.join(settings.MEDIA_URL, settings.PRODUCT_IMAGE_PATH, fn)
-        return '%s?%s' % (url, self.image_cachebuster)
+        return '{0!s}?{1!s}'.format(url, self.image_cachebuster)
 
     def questions_enabled(self, locale):
         return self.questions_locales.filter(locale=locale).exists()
@@ -140,7 +140,7 @@ class Topic(ModelBase):
         unique_together = ('slug', 'product')
 
     def __unicode__(self):
-        return u'[%s] %s' % (self.product.title, self.title)
+        return u'[{0!s}] {1!s}'.format(self.product.title, self.title)
 
     @property
     def image_url(self):
@@ -208,4 +208,4 @@ class Platform(ModelBase):
     display_order = models.IntegerField()
 
     def __unicode__(self):
-        return u'%s' % self.name
+        return u'{0!s}'.format(self.name)

--- a/kitsune/products/tests/__init__.py
+++ b/kitsune/products/tests/__init__.py
@@ -45,8 +45,8 @@ def version(**kwargs):
     v = randint(0, 1000)
 
     defaults = {
-        'name': 'Version %d.0' % v,
-        'slug': 'v%d' % v,
+        'name': 'Version {0:d}.0'.format(v),
+        'slug': 'v{0:d}'.format(v),
         'min_version': v,
         'max_version': v + 1,
         'visible': True,
@@ -66,8 +66,8 @@ def platform(**kwargs):
     v = randint(0, 1000)
 
     defaults = {
-        'name': 'Platform %d' % v,
-        'slug': 'platform%d' % v,
+        'name': 'Platform {0:d}'.format(v),
+        'slug': 'platform{0:d}'.format(v),
         'visible': True,
         'display_order': 0,
     }

--- a/kitsune/questions/cron.py
+++ b/kitsune/questions/cron.py
@@ -67,8 +67,8 @@ def auto_archive_old_questions():
         sql = """
             UPDATE questions_question
             SET is_archived = 1
-            WHERE id IN (%s)
-            """ % ','.join(map(str, q_ids))
+            WHERE id IN ({0!s})
+            """.format(','.join(map(str, q_ids)))
 
         cursor = connection.cursor()
         cursor.execute(sql)

--- a/kitsune/questions/events.py
+++ b/kitsune/questions/events.py
@@ -85,13 +85,12 @@ class QuestionReplyEvent(QuestionEvent):
 
             is_asker = asker_id == user.id
             if is_asker:
-                subject = _(u'%s posted an answer to your question "%s"' %
-                            (display_name(self.answer.creator),
+                subject = _(u'{0!s} posted an answer to your question "{1!s}"'.format(display_name(self.answer.creator),
                              self.instance.title))
                 text_template = 'questions/email/new_answer_to_asker.ltxt'
                 html_template = 'questions/email/new_answer_to_asker.html'
             else:
-                subject = _(u'Re: %s' % self.instance.title)
+                subject = _(u'Re: {0!s}'.format(self.instance.title))
                 text_template = 'questions/email/new_answer.ltxt'
                 html_template = 'questions/email/new_answer.html'
 

--- a/kitsune/questions/feeds.py
+++ b/kitsune/questions/feeds.py
@@ -84,7 +84,7 @@ class TaggedQuestionsFeed(QuestionsFeed):
         return get_object_or_404(Tag, slug=tag_slug)
 
     def title(self, tag):
-        return _('Recently updated questions tagged %s' % tag.name)
+        return _('Recently updated questions tagged {0!s}'.format(tag.name))
 
     def link(self, tag):
         return urlparams(reverse('questions.list', args=['all']),

--- a/kitsune/questions/management/commands/fix_weekly_votes.py
+++ b/kitsune/questions/management/commands/fix_weekly_votes.py
@@ -24,4 +24,4 @@ class Command(NoArgsCommand):
         transaction.commit()
         transaction.leave_transaction_management()
         d = time.time() - start
-        print u'Updated %d rows in %0.3f seconds.' % (rows, d)
+        print u'Updated {0:d} rows in {1:0.3f} seconds.'.format(rows, d)

--- a/kitsune/questions/marketplace.py
+++ b/kitsune/questions/marketplace.py
@@ -63,7 +63,7 @@ def submit_ticket(email, category, subject, body, tags):
         ticket_url = zendesk.create_ticket(data=new_ticket)
         statsd.incr('questions.zendesk.success')
     except ZendeskError as e:
-        log.error('Zendesk error: %s' % e.msg)
+        log.error('Zendesk error: {0!s}'.format(e.msg))
         statsd.incr('questions.zendesk.error')
         raise
 

--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -256,12 +256,12 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
         if version in dev_releases or \
            version in product_details.firefox_history_stability_releases or \
            version in product_details.firefox_history_major_releases:
-            to_add.append('Firefox %s' % version)
+            to_add.append('Firefox {0!s}'.format(version))
             tenths = _tenths_version(version)
             if tenths:
-                to_add.append('Firefox %s' % tenths)
+                to_add.append('Firefox {0!s}'.format(tenths))
         elif _has_beta(version, dev_releases):
-            to_add.append('Firefox %s' % version)
+            to_add.append('Firefox {0!s}'.format(version))
             to_add.append('beta')
 
         self.tags.add(*to_add)
@@ -498,7 +498,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             return []
 
         # First try to get the results from the cache
-        key = 'questions_question:related_docs:%s' % self.id
+        key = 'questions_question:related_docs:{0!s}'.format(self.id)
         documents = cache.get(key)
         if documents is not None:
             statsd.incr('questions.related_documents.cache.hit')
@@ -538,7 +538,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             return []
 
         # First try to get the results from the cache
-        key = 'questions_question:related_questions:%s' % self.id
+        key = 'questions_question:related_questions:{0!s}'.format(self.id)
         questions = cache.get(key)
         if questions is not None:
             statsd.incr('questions.related_questions.cache.hit')
@@ -845,7 +845,7 @@ class QuestionMetaData(ModelBase):
         unique_together = ('question', 'name')
 
     def __unicode__(self):
-        return u'%s: %s' % (self.name, self.value[:50])
+        return u'{0!s}: {1!s}'.format(self.name, self.value[:50])
 
 
 class QuestionVisits(ModelBase):
@@ -935,7 +935,7 @@ class Answer(ModelBase, SearchMixin):
         )
 
     def __unicode__(self):
-        return u'%s: %s' % (self.question.title, self.content[:50])
+        return u'{0!s}: {1!s}'.format(self.question.title, self.content[:50])
 
     @property
     def content_parsed(self):
@@ -1020,7 +1020,7 @@ class Answer(ModelBase, SearchMixin):
         url = reverse('questions.answer_vote',
                       kwargs={'question_id': self.question_id,
                               'answer_id': self.id})
-        return '%s?%s' % (url, 'helpful')
+        return '{0!s}?{1!s}'.format(url, 'helpful')
 
     def get_solution_url(self, watch):
         url = reverse('questions.solve',
@@ -1035,7 +1035,7 @@ class Answer(ModelBase, SearchMixin):
 
         url = reverse('questions.details',
                       kwargs={'question_id': self.question_id})
-        return urlparams(url, hash='answer-%s' % self.id, **query)
+        return urlparams(url, hash='answer-{0!s}'.format(self.id), **query)
 
     @property
     def num_votes(self):
@@ -1210,7 +1210,7 @@ class AnswerMetricsMappingType(SearchMappingType):
         # doesn't change much, so this is probably ok.
         url = reverse('questions.details',
                       kwargs={'question_id': obj_dict['question_id']})
-        d['url'] = urlparams(url, hash='answer-%s' % obj_dict['id'])
+        d['url'] = urlparams(url, hash='answer-{0!s}'.format(obj_dict['id']))
 
         d['indexed_on'] = int(time.time())
 

--- a/kitsune/questions/tests/test_es.py
+++ b/kitsune/questions/tests/test_es.py
@@ -21,7 +21,7 @@ class QuestionUpdateTests(ElasticTestCase):
         # Create a question--that adds one document to the index.
         q = question(title=u'Does this test work?', save=True)
         self.refresh()
-        query = dict(('%s__match' % field, 'test')
+        query = dict(('{0!s}__match'.format(field), 'test')
                      for field in QuestionMappingType.get_query_fields())
         eq_(search.query(should=True, **query).count(), 1)
 
@@ -30,13 +30,13 @@ class QuestionUpdateTests(ElasticTestCase):
         a = answer(content=u'There\'s only one way to find out!',
                    question=q)
         self.refresh()
-        query = dict(('%s__match' % field, 'only')
+        query = dict(('{0!s}__match'.format(field), 'only')
                      for field in QuestionMappingType.get_query_fields())
         eq_(search.query(should=True, **query).count(), 0)
 
         a.save()
         self.refresh()
-        query = dict(('%s__match' % field, 'only')
+        query = dict(('{0!s}__match'.format(field), 'only')
                      for field in QuestionMappingType.get_query_fields())
         eq_(search.query(should=True, **query).count(), 1)
 

--- a/kitsune/questions/tests/test_models.py
+++ b/kitsune/questions/tests/test_models.py
@@ -130,7 +130,7 @@ class TestAnswer(TestCaseBase):
         a1.save()
         a2.delete()
         a3 = Answer.objects.filter(question=a1.question)[0]
-        assert a3.page == 1, "Page was %s" % a3.page
+        assert a3.page == 1, "Page was {0!s}".format(a3.page)
 
     def test_creator_num_answers(self):
         a = answer(save=True)
@@ -157,9 +157,9 @@ class TestAnswer(TestCaseBase):
         doc.save()
 
         q = question(locale='es', save=True)
-        a = answer(question=q, content='[[%s]]' % doc.title, save=True)
+        a = answer(question=q, content='[[{0!s}]]'.format(doc.title), save=True)
 
-        assert 'es/kb/%s' % doc.slug in a.content_parsed
+        assert 'es/kb/{0!s}'.format(doc.slug) in a.content_parsed
 
     def test_creator_follows(self):
         a = answer(save=True)
@@ -372,9 +372,9 @@ class QuestionTests(TestCaseBase):
         """Verify question returned from valid URL."""
         q = question(save=True)
 
-        eq_(q, Question.from_url('/en-US/questions/%s' % q.id))
-        eq_(q, Question.from_url('/es/questions/%s' % q.id))
-        eq_(q, Question.from_url('/questions/%s' % q.id))
+        eq_(q, Question.from_url('/en-US/questions/{0!s}'.format(q.id)))
+        eq_(q, Question.from_url('/es/questions/{0!s}'.format(q.id)))
+        eq_(q, Question.from_url('/questions/{0!s}'.format(q.id)))
 
     def test_from_url_id_only(self):
         """Verify question returned from valid URL."""
@@ -387,8 +387,8 @@ class QuestionTests(TestCaseBase):
         """Verify question returned from valid URL."""
         q = question(save=True)
 
-        eq_(None, Question.from_url('/en-US/questions/%s/edit' % q.id))
-        eq_(None, Question.from_url('/en-US/kb/%s' % q.id))
+        eq_(None, Question.from_url('/en-US/questions/{0!s}/edit'.format(q.id)))
+        eq_(None, Question.from_url('/en-US/kb/{0!s}'.format(q.id)))
         eq_(None, Question.from_url('/random/url'))
         eq_(None, Question.from_url('/en-US/questions/dashboard/metrics'))
 
@@ -415,9 +415,8 @@ class QuestionTests(TestCaseBase):
         # This test relies on datetime.now() being called in the age
         # property, so this delta check makes it less likely to fail
         # randomly.
-        assert abs(q1.age - 10 * 24 * 60 * 60) < 2, ('q1.age (%s) != 10 days'
-                                                     % q1.age)
-        assert abs(q2.age - 30) < 2, 'q2.age (%s) != 30 seconds' % q2.age
+        assert abs(q1.age - 10 * 24 * 60 * 60) < 2, ('q1.age ({0!s}) != 10 days'.format(q1.age))
+        assert abs(q2.age - 30) < 2, 'q2.age ({0!s}) != 30 seconds'.format(q2.age)
 
     def test_is_taken(self):
         q = question(save=True)

--- a/kitsune/questions/tests/test_notifications.py
+++ b/kitsune/questions/tests/test_notifications.py
@@ -137,10 +137,10 @@ class NotificationsTests(TestCaseBase):
         # Make sure 'before' values are the reverse.
         if turn_on:
             assert not event_cls.is_notifying(user, q), (
-                '%s should not be notifying.' % event_cls.__name__)
+                '{0!s} should not be notifying.'.format(event_cls.__name__))
         else:
             assert event_cls.is_notifying(user, q), (
-                '%s should be notifying.' % event_cls.__name__)
+                '{0!s} should be notifying.'.format(event_cls.__name__))
 
         url = 'questions.watch' if turn_on else 'questions.unwatch'
         data = {'event_type': event_type} if turn_on else {}
@@ -148,10 +148,10 @@ class NotificationsTests(TestCaseBase):
 
         if turn_on:
             assert event_cls.is_notifying(user, q), (
-                '%s should be notifying.' % event_cls.__name__)
+                '{0!s} should be notifying.'.format(event_cls.__name__))
         else:
             assert not event_cls.is_notifying(user, q), (
-                '%s should not be notifying.' % event_cls.__name__)
+                '{0!s} should not be notifying.'.format(event_cls.__name__))
         return q
 
     @mock.patch.object(Site.objects, 'get_current')

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -62,7 +62,7 @@ class AnswersTemplateTestCase(TestCaseBase):
         eq_(content, new_answer.content)
         # Check canonical url
         doc = pq(response.content)
-        eq_('/questions/%s' % self.question.id,
+        eq_('/questions/{0!s}'.format(self.question.id),
             doc('link[rel="canonical"]')[0].attrib['href'])
 
     def test_answer_upload(self):
@@ -82,7 +82,7 @@ class AnswersTemplateTestCase(TestCaseBase):
         eq_(1, new_answer.images.count())
         image = new_answer.images.all()[0]
         name = '098f6b.png'
-        message = 'File name "%s" does not contain "%s"' % (
+        message = 'File name "{0!s}" does not contain "{1!s}"'.format(
             image.file.name, name)
         assert name in image.file.name, message
         eq_(self.user.username, image.creator.username)
@@ -143,7 +143,7 @@ class AnswersTemplateTestCase(TestCaseBase):
         doc = pq(response.content)
         eq_(1, len(doc('div.solution')))
         div = doc('h3.is-solution')[0].getparent().getparent()
-        eq_('answer-%s' % ans.id, div.attrib['id'])
+        eq_('answer-{0!s}'.format(ans.id), div.attrib['id'])
         q = Question.objects.get(pk=self.question.id)
         eq_(q.solution, ans)
         eq_(q.solver, self.question.creator)
@@ -296,7 +296,7 @@ class AnswersTemplateTestCase(TestCaseBase):
                        args=[self.question.id])
         doc = pq(response.content)
 
-        eq_(1, len(doc('#answer-%s h3.is-helpful' % self.answer.id)))
+        eq_(1, len(doc('#answer-{0!s} h3.is-helpful'.format(self.answer.id))))
         eq_(0, len(doc('form.helpful input[name="helpful"]')))
         # Verify user agent
         vote_meta = VoteMetadata.objects.all()[0]
@@ -366,16 +366,14 @@ class AnswersTemplateTestCase(TestCaseBase):
                        args=[self.question.id])
         redirect = response.redirect_chain[0]
         eq_(302, redirect[1])
-        eq_('http://testserver/%s%s?next=/en-US/questions/%s/delete' %
-            (settings.LANGUAGE_CODE, settings.LOGIN_URL, self.question.id),
+        eq_('http://testserver/{0!s}{1!s}?next=/en-US/questions/{2!s}/delete'.format(settings.LANGUAGE_CODE, settings.LOGIN_URL, self.question.id),
             redirect[0])
 
         response = post(self.client, 'questions.delete',
                         args=[self.question.id])
         redirect = response.redirect_chain[0]
         eq_(302, redirect[1])
-        eq_('http://testserver/%s%s?next=/en-US/questions/%s/delete' %
-            (settings.LANGUAGE_CODE, settings.LOGIN_URL, self.question.id),
+        eq_('http://testserver/{0!s}{1!s}?next=/en-US/questions/{2!s}/delete'.format(settings.LANGUAGE_CODE, settings.LOGIN_URL, self.question.id),
             redirect[0])
 
     def test_delete_question_with_permissions(self):
@@ -413,16 +411,14 @@ class AnswersTemplateTestCase(TestCaseBase):
                        args=[self.question.id, ans.id])
         redirect = response.redirect_chain[0]
         eq_(302, redirect[1])
-        eq_('http://testserver/%s%s?next=/en-US/questions/%s/delete/%s' %
-            (settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id, ans.id),
+        eq_('http://testserver/{0!s}{1!s}?next=/en-US/questions/{2!s}/delete/{3!s}'.format(settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id, ans.id),
             redirect[0])
 
         response = post(self.client, 'questions.delete_answer',
                         args=[self.question.id, ans.id])
         redirect = response.redirect_chain[0]
         eq_(302, redirect[1])
-        eq_('http://testserver/%s%s?next=/en-US/questions/%s/delete/%s' %
-            (settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id, ans.id),
+        eq_('http://testserver/{0!s}{1!s}?next=/en-US/questions/{2!s}/delete/{3!s}'.format(settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id, ans.id),
             redirect[0])
 
     def test_delete_answer_with_permissions(self):
@@ -502,7 +498,7 @@ class AnswersTemplateTestCase(TestCaseBase):
         doc = pq(response.content)
         eq_(1, len(doc('li.edit')))
         new_answer = self.question.answers.order_by('-id')[0]
-        eq_(1, len(doc('#answer-%s + div li.edit' % new_answer.id)))
+        eq_(1, len(doc('#answer-{0!s} + div li.edit'.format(new_answer.id))))
 
         # Make sure it can be edited
         content = 'New content for answer'
@@ -534,8 +530,7 @@ class AnswersTemplateTestCase(TestCaseBase):
         response = post(self.client, 'questions.lock', args=[q.id])
         redirect = response.redirect_chain[0]
         eq_(302, redirect[1])
-        eq_('http://testserver/%s%s?next=/en-US/questions/%s/lock' %
-            (settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id), redirect[0])
+        eq_('http://testserver/{0!s}{1!s}?next=/en-US/questions/{2!s}/lock'.format(settings.LANGUAGE_CODE, settings.LOGIN_URL, q.id), redirect[0])
 
     def test_lock_question_with_permissions_GET(self):
         """Trying to lock a question via HTTP GET."""
@@ -858,10 +853,10 @@ class TaggingViewTestsAsTagger(TestCaseBase):
     def test_add_tag_get_method(self):
         """Assert GETting the add_tag view redirects to the answers page."""
         response = self.client.get(_add_tag_url(self.question.id))
-        url = 'http://testserver%s' % reverse(
+        url = 'http://testserver{0!s}'.format(reverse(
             'questions.details',
             kwargs={'question_id': self.question.id},
-            force_locale=True)
+            force_locale=True))
         self.assertRedirects(response, url)
 
     def test_add_nonexistent_tag(self):
@@ -938,9 +933,9 @@ class TaggingViewTestsAsTagger(TestCaseBase):
         self._assert_redirects_to_question(response, self.question.id)
 
     def _assert_redirects_to_question(self, response, question_id):
-        url = 'http://testserver%s' % reverse(
+        url = 'http://testserver{0!s}'.format(reverse(
             'questions.details', kwargs={'question_id': question_id},
-            force_locale=True)
+            force_locale=True))
         self.assertRedirects(response, url)
 
     # remove_tag_async view:
@@ -1124,7 +1119,7 @@ class QuestionsTemplateTestCase(TestCaseBase):
             eq_(len(expected), len(doc('.questions > section')))
 
             for q in expected:
-                eq_(1, len(doc('.questions > section[id=question-%s]' % q.id)))
+                eq_(1, len(doc('.questions > section[id=question-{0!s}]'.format(q.id))))
 
         # No filtering -> All questions.
         check('all', [q1, q2, q3])
@@ -1135,11 +1130,11 @@ class QuestionsTemplateTestCase(TestCaseBase):
         # Filter on p3 -> No results
         check(p3.slug, [])
         # Filter on p1,p2
-        check('%s,%s' % (p1.slug, p2.slug), [q2, q3])
+        check('{0!s},{1!s}'.format(p1.slug, p2.slug), [q2, q3])
         # Filter on p1,p3
-        check('%s,%s' % (p1.slug, p3.slug), [q2])
+        check('{0!s},{1!s}'.format(p1.slug, p3.slug), [q2])
         # Filter on p2,p3
-        check('%s,%s' % (p2.slug, p3.slug), [q3])
+        check('{0!s},{1!s}'.format(p2.slug, p3.slug), [q3])
 
     def test_topic_filter(self):
         p = product(save=True)
@@ -1163,7 +1158,7 @@ class QuestionsTemplateTestCase(TestCaseBase):
             # eq_(len(expected), len(doc('.questions > section')))
 
             for q in expected:
-                eq_(1, len(doc('.questions > section[id=question-%s]' % q.id)))
+                eq_(1, len(doc('.questions > section[id=question-{0!s}]'.format(q.id))))
 
         # No filtering -> All questions.
         check({}, [q1, q2, q3])
@@ -1197,13 +1192,13 @@ class QuestionsTemplateTestCase(TestCaseBase):
         """Verify we strip html from truncated text."""
         long_str = ''.join(random.choice(letters) for x in xrange(170))
         question(
-            content='<p>%s</p>' % long_str,
+            content='<p>{0!s}</p>'.format(long_str),
             save=True)
         response = self.client.get(reverse('questions.list', args=['all']))
 
         # Verify that the <p> was stripped
         assert '<p class="short-text"><p>' not in response.content
-        assert '<p class="short-text">%s' % long_str[:5] in response.content
+        assert '<p class="short-text">{0!s}'.format(long_str[:5]) in response.content
 
     def test_views(self):
         """Verify the view count is displayed correctly."""
@@ -1276,9 +1271,9 @@ class QuestionEditingTests(TestCaseBase):
         extra_fields = (q.product_config.get('extra_fields', []) +
                         q.category_config.get('extra_fields', []))
         for field in extra_fields:
-            assert (doc('input[name=%s]' % field) or
-                    doc('textarea[name=%s]' % field)), (
-                "The %s field is missing from the edit page." % field)
+            assert (doc('input[name={0!s}]'.format(field)) or
+                    doc('textarea[name={0!s}]'.format(field))), (
+                "The {0!s} field is missing from the edit page.".format(field))
 
     def test_no_extra_fields(self):
         """The edit-question form shouldn't show inappropriate metadata."""
@@ -1302,9 +1297,9 @@ class QuestionEditingTests(TestCaseBase):
                         kwargs={'question_id': q.id})
 
         # Make sure the form redirects and thus appears to succeed:
-        url = 'http://testserver%s' % reverse('questions.details',
+        url = 'http://testserver{0!s}'.format(reverse('questions.details',
                                               kwargs={'question_id': q.id},
-                                              force_locale=True)
+                                              force_locale=True))
         self.assertRedirects(response, url)
 
         # Make sure the static fields, the metadata, and the updated_by field
@@ -1386,7 +1381,7 @@ class AAQTemplateTestCase(TestCaseBase):
         # Make sure question is in questions list
         response = self.client.get(reverse('questions.list', args=['all']))
         doc = pq(response.content)
-        eq_(1, len(doc('#question-%s' % question.id)))
+        eq_(1, len(doc('#question-{0!s}'.format(question.id))))
         # And no email was sent
         eq_(0, len(mail.outbox))
 
@@ -1426,7 +1421,7 @@ class AAQTemplateTestCase(TestCaseBase):
         # Make sure question is not in questions list
         response = self.client.get(reverse('questions.list', args=['all']))
         doc = pq(response.content)
-        eq_(0, len(doc('li#question-%s' % question.id)))
+        eq_(0, len(doc('li#question-{0!s}'.format(question.id))))
         # And no confirmation email was sent (already sent on registration)
         eq_(0, len(mail.outbox))
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -245,10 +245,10 @@ def question_list(request, template, product_slug):
     # Set the order.
     order_by = ORDER_BY[order][0]
     question_qs = question_qs.order_by(
-        order_by if sort == 'asc' else '-%s' % order_by)
+        order_by if sort == 'asc' else '-{0!s}'.format(order_by))
 
     try:
-        with statsd.timer('questions.view.paginate.%s' % filter_):
+        with statsd.timer('questions.view.paginate.{0!s}'.format(filter_)):
             questions_page = simple_paginate(
                 request, question_qs, per_page=config.QUESTIONS_PER_PAGE)
     except (PageNotAnInteger, EmptyPage):
@@ -1232,8 +1232,7 @@ def delete_question(request, question_id):
     product = question.product_slug
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting question with id=%s' %
-                (request.user, question.id))
+    log.warning('User {0!s} is deleting question with id={1!s}'.format(request.user, question.id))
     question.delete()
 
     statsd.incr('questions.delete')
@@ -1255,8 +1254,7 @@ def delete_answer(request, question_id, answer_id):
             'answer': answer})
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting answer with id=%s' %
-                (request.user, answer.id))
+    log.warning('User {0!s} is deleting answer with id={1!s}'.format(request.user, answer.id))
     answer.delete()
 
     statsd.incr('questions.delete_answer')
@@ -1275,8 +1273,7 @@ def lock_question(request, question_id):
         raise PermissionDenied
 
     question.is_locked = not question.is_locked
-    log.info("User %s set is_locked=%s on question with id=%s " %
-             (request.user, question.is_locked, question.id))
+    log.info("User {0!s} set is_locked={1!s} on question with id={2!s} ".format(request.user, question.is_locked, question.id))
     question.save()
 
     if question.is_locked:
@@ -1297,8 +1294,7 @@ def archive_question(request, question_id):
         raise PermissionDenied
 
     question.is_archived = not question.is_archived
-    log.info("User %s set is_archived=%s on question with id=%s " %
-             (request.user, question.is_archived, question.id))
+    log.info("User {0!s} set is_archived={1!s} on question with id={2!s} ".format(request.user, question.is_archived, question.id))
     question.save()
 
     return HttpResponseRedirect(question.get_absolute_url())
@@ -1330,8 +1326,7 @@ def edit_answer(request, question_id, answer_id):
             answer.updated = datetime.now()
             answer_preview = answer
         else:
-            log.warning('User %s is editing answer with id=%s' %
-                        (request.user, answer.id))
+            log.warning('User {0!s} is editing answer with id={1!s}'.format(request.user, answer.id))
             answer.save()
             return HttpResponseRedirect(answer.get_absolute_url())
 
@@ -1700,7 +1695,7 @@ def screen_share(request, question_id):
     message = jingo.render_to_string(request, 'questions/message/screen_share.ltxt', {
         'asker': display_name(question.creator), 'contributor': display_name(request.user)})
 
-    return HttpResponseRedirect('%s?to=%s&message=%s' % (reverse('messages.new'),
+    return HttpResponseRedirect('{0!s}?to={1!s}&message={2!s}'.format(reverse('messages.new'),
                                                          question.creator.username,
                                                          message))
 
@@ -1743,9 +1738,9 @@ def _search_suggestions(request, text, locale, product_slugs):
     results = []
     try:
         # Search for relevant KB documents.
-        query = dict(('%s__match' % field, text)
+        query = dict(('{0!s}__match'.format(field), text)
                      for field in DocumentMappingType.get_query_fields())
-        query.update(dict(('%s__match_phrase' % field, text)
+        query.update(dict(('{0!s}__match_phrase'.format(field), text)
                      for field in DocumentMappingType.get_query_fields()))
         query = es_query_with_analyzer(query, locale)
         filter = F()
@@ -1777,9 +1772,9 @@ def _search_suggestions(request, text, locale, product_slugs):
                 pass
 
         # Search for relevant questions.
-        query = dict(('%s__match' % field, text)
+        query = dict(('{0!s}__match'.format(field), text)
                      for field in QuestionMappingType.get_query_fields())
-        query.update(dict(('%s__match_phrase' % field, text)
+        query.update(dict(('{0!s}__match_phrase'.format(field), text)
                      for field in QuestionMappingType.get_query_fields()))
 
         # Filter questions by language. Questions should be either in English

--- a/kitsune/search/admin.py
+++ b/kitsune/search/admin.py
@@ -55,17 +55,17 @@ def handle_delete(request):
 
     # Rule 1: Has to start with the ES_INDEX_PREFIX.
     if not index_to_delete.startswith(settings.ES_INDEX_PREFIX):
-        raise DeleteError('"%s" is not a valid index name.' % index_to_delete)
+        raise DeleteError('"{0!s}" is not a valid index name.'.format(index_to_delete))
 
     # Rule 2: Must be an existing index.
     if index_to_delete not in es_indexes:
-        raise DeleteError('"%s" does not exist.' % index_to_delete)
+        raise DeleteError('"{0!s}" does not exist.'.format(index_to_delete))
 
     # Rule 3: Don't delete the default read index.
     # TODO: When the critical index exists, this should be "Don't
     # delete the critical read index."
     if index_to_delete == read_index('default'):
-        raise DeleteError('"%s" is the default read index.' % index_to_delete)
+        raise DeleteError('"{0!s}" is the default read index.'.format(index_to_delete))
 
     # The index is ok to delete
     delete_index(index_to_delete)
@@ -90,7 +90,7 @@ def reindex_with_scoreboard(mapping_type_names):
         client = redis_client('default')
         val = client.get(OUTSTANDING_INDEX_CHUNKS)
         if val is not None and int(val) > 0:
-            raise ReindexError('There are %s outstanding chunks.' % val)
+            raise ReindexError('There are {0!s} outstanding chunks.'.format(val))
 
         # We don't know how many chunks we're building, but we do want
         # to make sure another reindex request doesn't slide in here
@@ -168,25 +168,25 @@ def search(request):
         try:
             return handle_reset(request)
         except ReindexError as e:
-            error_messages.append(u'Error: %s' % e.message)
+            error_messages.append(u'Error: {0!s}'.format(e.message))
 
     if 'reindex' in request.POST:
         try:
             return handle_reindex(request)
         except ReindexError as e:
-            error_messages.append(u'Error: %s' % e.message)
+            error_messages.append(u'Error: {0!s}'.format(e.message))
 
     if 'recreate_index' in request.POST:
         try:
             return handle_recreate_index(request)
         except ReindexError as e:
-            error_messages.append(u'Error: %s' % e.message)
+            error_messages.append(u'Error: {0!s}'.format(e.message))
 
     if 'delete_index' in request.POST:
         try:
             return handle_delete(request)
         except DeleteError as e:
-            error_messages.append(u'Error: %s' % e.message)
+            error_messages.append(u'Error: {0!s}'.format(e.message))
         except ES_EXCEPTIONS as e:
             error_messages.append('Error: {0}'.format(repr(e)))
 

--- a/kitsune/search/es_utils.py
+++ b/kitsune/search/es_utils.py
@@ -21,13 +21,13 @@ from kitsune.search.utils import chunked
 
 def read_index(group):
     """Gets the name of the read index for a group."""
-    return (u'%s_%s' % (settings.ES_INDEX_PREFIX,
+    return (u'{0!s}_{1!s}'.format(settings.ES_INDEX_PREFIX,
                         settings.ES_INDEXES[group]))
 
 
 def write_index(group):
     """Gets the name of the write index for a group."""
-    return (u'%s_%s' % (settings.ES_INDEX_PREFIX,
+    return (u'{0!s}_{1!s}'.format(settings.ES_INDEX_PREFIX,
                         settings.ES_WRITE_INDEXES[group]))
 
 
@@ -244,8 +244,8 @@ def delete_index(index):
 def format_time(time_to_go):
     """Returns minutes and seconds string for given time in seconds"""
     if time_to_go < 60:
-        return "%ds" % time_to_go
-    return "%dm %ds" % (time_to_go / 60, time_to_go % 60)
+        return "{0:d}s".format(time_to_go)
+    return "{0:d}m {1:d}s".format(time_to_go / 60, time_to_go % 60)
 
 
 def get_documents(cls, ids):
@@ -751,7 +751,7 @@ def es_status_cmd(checkindex=False, log=log):
                             missing_docs += 1
 
         if missing_docs:
-            print 'There were %d missing_docs' % missing_docs
+            print 'There were {0:d} missing_docs'.format(missing_docs)
 
 
 def es_search_cmd(query, pages=1, log=log):
@@ -769,7 +769,7 @@ def es_search_cmd(query, pages=1, log=log):
     client = LocalizingClient()
 
     output = []
-    output.append('Search for: %s' % query)
+    output.append('Search for: {0!s}'.format(query))
     output.append('')
 
     data = {'q': query, 'format': 'json'}
@@ -782,7 +782,7 @@ def es_search_cmd(query, pages=1, log=log):
         data['page'] = pageno
         resp = client.get(url, data)
         if resp.status_code != 200:
-            output.append('ERROR: %s' % resp.content)
+            output.append('ERROR: {0!s}'.format(resp.content))
             break
 
         else:
@@ -790,7 +790,7 @@ def es_search_cmd(query, pages=1, log=log):
             results = content[u'results']
 
             for mem in results:
-                output.append(u'%4d  %5.2f  %-10s  %-20s' % (
+                output.append(u'{0:4d}  {1:5.2f}  {2:<10!s}  {3:<20!s}'.format(
                               mem['rank'], mem['score'], mem['type'],
                               mem['title']))
 
@@ -827,8 +827,7 @@ def es_verify_cmd(log=log):
                 # work for non-trivial dicts.
                 if merged_mapping[key][0] != val:
                     raise MappingMergeError(
-                        '%s key different for %s and %s' %
-                        (key, cls_name, merged_mapping[key][1]))
+                        '{0!s} key different for {1!s} and {2!s}'.format(key, cls_name, merged_mapping[key][1]))
 
                 merged_mapping[key][1].append(cls_name)
 

--- a/kitsune/search/models.py
+++ b/kitsune/search/models.py
@@ -244,8 +244,7 @@ def register_for_indexing(app,
         return receiver(
             signal,
             sender=sender_class,
-            dispatch_uid='%s.%s.elastic.%s' %
-                         (app, sender_class.__name__, signal_name),
+            dispatch_uid='{0!s}.{1!s}.elastic.{2!s}'.format(app, sender_class.__name__, signal_name),
             weak=False)
 
     if m2m:

--- a/kitsune/search/synonym_utils.py
+++ b/kitsune/search/synonym_utils.py
@@ -38,9 +38,9 @@ def parse_synonyms(text):
             continue
         count = line.count('=>')
         if count < 1:
-            errors.append('Syntax error on line %d: No => found.' % i)
+            errors.append('Syntax error on line {0:d}: No => found.'.format(i))
         elif count > 1:
-            errors.append('Syntax error on line %d: Too many => found.' % i)
+            errors.append('Syntax error on line {0:d}: Too many => found.'.format(i))
         else:
             from_words, to_words = [s.strip() for s in line.split('=>')]
             synonyms.add((from_words, to_words))

--- a/kitsune/search/tasks.py
+++ b/kitsune/search/tasks.py
@@ -162,7 +162,7 @@ MAX_RETRIES = len(RETRY_TIMES)
 @timeit
 def index_task(cls, id_list, **kw):
     """Index documents specified by cls and ids"""
-    statsd.incr('search.tasks.index_task.%s' % cls.get_mapping_type_name())
+    statsd.incr('search.tasks.index_task.{0!s}'.format(cls.get_mapping_type_name()))
     try:
         # Pin to master db to avoid replication lag issues and stale
         # data.
@@ -186,7 +186,7 @@ def index_task(cls, id_list, **kw):
             raise IndexingTaskError()
 
         statsd.incr('search.tasks.index_task.retry', 1)
-        statsd.incr('search.tasks.index_task.retry%d' % RETRY_TIMES[retries],
+        statsd.incr('search.tasks.index_task.retry{0:d}'.format(RETRY_TIMES[retries]),
                     1)
 
         index_task.retry(exc=exc, max_retries=MAX_RETRIES,
@@ -199,7 +199,7 @@ def index_task(cls, id_list, **kw):
 @timeit
 def unindex_task(cls, id_list, **kw):
     """Unindex documents specified by cls and ids"""
-    statsd.incr('search.tasks.unindex_task.%s' % cls.get_mapping_type_name())
+    statsd.incr('search.tasks.unindex_task.{0!s}'.format(cls.get_mapping_type_name()))
     try:
         # Pin to master db to avoid replication lag issues and stale
         # data.
@@ -214,7 +214,7 @@ def unindex_task(cls, id_list, **kw):
             raise IndexingTaskError()
 
         statsd.incr('search.tasks.unindex_task.retry', 1)
-        statsd.incr('search.tasks.unindex_task.retry%d' % RETRY_TIMES[retries],
+        statsd.incr('search.tasks.unindex_task.retry{0:d}'.format(RETRY_TIMES[retries]),
                     1)
 
         unindex_task.retry(exc=exc, max_retries=MAX_RETRIES,

--- a/kitsune/search/tests/test_es.py
+++ b/kitsune/search/tests/test_es.py
@@ -128,8 +128,7 @@ class TestMappings(unittest.TestCase):
                     # not work for non-trivial dicts.
                     if merged_mapping[key][0] != val:
                         raise es_utils.MappingMergeError(
-                            '%s key different for %s and %s' %
-                            (key, cls_name, merged_mapping[key][1]))
+                            '{0!s} key different for {1!s} and {2!s}'.format(key, cls_name, merged_mapping[key][1]))
 
                     merged_mapping[key][1].append(cls_name)
 

--- a/kitsune/search/tests/test_search_simple.py
+++ b/kitsune/search/tests/test_search_simple.py
@@ -47,11 +47,11 @@ class SimpleSearchTests(ElasticTestCase):
     def test_headers(self):
         """Verify caching headers of search forms and search results"""
         response = self.client.get(reverse('search'), {'q': 'audio'})
-        eq_('max-age=%s' % (settings.SEARCH_CACHE_PERIOD * 60),
+        eq_('max-age={0!s}'.format((settings.SEARCH_CACHE_PERIOD * 60)),
             response['Cache-Control'])
         assert 'Expires' in response
         response = self.client.get(reverse('search'))
-        eq_('max-age=%s' % (settings.SEARCH_CACHE_PERIOD * 60),
+        eq_('max-age={0!s}'.format((settings.SEARCH_CACHE_PERIOD * 60)),
             response['Cache-Control'])
         assert 'Expires' in response
 

--- a/kitsune/search/utils.py
+++ b/kitsune/search/utils.py
@@ -25,7 +25,7 @@ class FakeLogger(object):
 
     def _out(self, level, msg, *args):
         msg = msg % args
-        self.stdout.write('%s %-8s: %s\n' % (
+        self.stdout.write('{0!s} {1:<8!s}: {2!s}\n'.format(
                           time.strftime('%H:%M:%S'), level, msg))
 
     def info(self, msg, *args):

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -108,7 +108,7 @@ def simple_search(request, template=None):
             'advanced': False, 'request': request,
             'search_form': search_form})
         cache_period = settings.SEARCH_CACHE_PERIOD
-        search_['Cache-Control'] = 'max-age=%s' % (cache_period * 60)
+        search_['Cache-Control'] = 'max-age={0!s}'.format((cache_period * 60))
         search_['Expires'] = (
             (datetime.utcnow() + timedelta(minutes=cache_period))
             .strftime(EXPIRES_FMT))
@@ -184,7 +184,7 @@ def simple_search(request, template=None):
 
         # These filters are ternary, they can be either YES, NO, or OFF
         ternary_filters = ('has_helpful', 'is_archived')
-        d = dict(('question_%s' % filter_name,
+        d = dict(('question_{0!s}'.format(filter_name),
                   _ternary_filter(cleaned[filter_name]))
                  for filter_name in ternary_filters if cleaned[filter_name])
         if d:
@@ -253,7 +253,7 @@ def simple_search(request, template=None):
         # we want to search.
         for field in query_fields:
             for query_type in ['match', 'match_phrase']:
-                query['%s__%s' % (field, query_type)] = cleaned_q
+                query['{0!s}__{1!s}'.format(field, query_type)] = cleaned_q
 
         # Transform the query to use locale aware analyzers.
         query = es_utils.es_query_with_analyzer(query, language)
@@ -415,7 +415,7 @@ def simple_search(request, template=None):
     })
     results_ = render(request, template, data)
     cache_period = settings.SEARCH_CACHE_PERIOD
-    results_['Cache-Control'] = 'max-age=%s' % (cache_period * 60)
+    results_['Cache-Control'] = 'max-age={0!s}'.format((cache_period * 60))
     results_['Expires'] = (
         (datetime.utcnow() + timedelta(minutes=cache_period))
         .strftime(EXPIRES_FMT))
@@ -476,7 +476,7 @@ def advanced_search(request, template=None):
             'advanced': True, 'request': request,
             'search_form': search_form})
         cache_period = settings.SEARCH_CACHE_PERIOD
-        search_['Cache-Control'] = 'max-age=%s' % (cache_period * 60)
+        search_['Cache-Control'] = 'max-age={0!s}'.format((cache_period * 60))
         search_['Expires'] = (
             (datetime.utcnow() + timedelta(minutes=cache_period))
             .strftime(EXPIRES_FMT))
@@ -537,7 +537,7 @@ def advanced_search(request, template=None):
         # These filters are ternary, they can be either YES, NO, or OFF
         ternary_filters = ('is_locked', 'is_solved', 'has_answers',
                            'has_helpful', 'is_archived')
-        d = dict(('question_%s' % filter_name,
+        d = dict(('question_{0!s}'.format(filter_name),
                   _ternary_filter(cleaned[filter_name]))
                  for filter_name in ternary_filters if cleaned[filter_name])
         if d:
@@ -712,7 +712,7 @@ def advanced_search(request, template=None):
             # Create a simple_query_search query for every field
             # we want to search.
             for field in query_fields:
-                query['%s__sqs' % field] = cleaned_q
+                query['{0!s}__sqs'.format(field)] = cleaned_q
 
             # Transform the query to use locale aware analyzers.
             query = es_utils.es_query_with_analyzer(query, language)
@@ -879,7 +879,7 @@ def advanced_search(request, template=None):
         'search_form': search_form, })
     results_ = render(request, template, data)
     cache_period = settings.SEARCH_CACHE_PERIOD
-    results_['Cache-Control'] = 'max-age=%s' % (cache_period * 60)
+    results_['Cache-Control'] = 'max-age={0!s}'.format((cache_period * 60))
     results_['Expires'] = (
         (datetime.utcnow() + timedelta(minutes=cache_period))
         .strftime(EXPIRES_FMT))
@@ -901,7 +901,7 @@ def suggestions(request):
     site = Site.objects.get_current()
     locale = locale_or_default(request.LANGUAGE_CODE)
     try:
-        query = dict(('%s__match' % field, term)
+        query = dict(('{0!s}__match'.format(field), term)
                      for field in DocumentMappingType.get_query_fields())
         # Upgrade the query to an analyzer-aware one.
         query = es_utils.es_query_with_analyzer(query, locale)
@@ -912,7 +912,7 @@ def suggestions(request):
                   .values_dict('document_title', 'url')
                   .query(or_=query)[:5])
 
-        query = dict(('%s__match' % field, term)
+        query = dict(('{0!s}__match'.format(field), term)
                      for field in QuestionMappingType.get_query_fields())
         question_s = (QuestionMappingType.search()
                       .filter(question_has_helpful=True)
@@ -926,7 +926,7 @@ def suggestions(request):
         results = []
 
     def urlize(r):
-        return u'https://%s%s' % (site, r['url'])
+        return u'https://{0!s}{1!s}'.format(site, r['url'])
 
     def titleize(r):
         return r.get('document_title', r.get('document_title'))

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -490,7 +490,7 @@ PASSWORD_HASHERS = (
 
 USERNAME_BLACKLIST = path('kitsune', 'configs', 'username-blacklist.txt')
 
-ROOT_URLCONF = '%s.urls' % PROJECT_MODULE
+ROOT_URLCONF = '{0!s}.urls'.format(PROJECT_MODULE)
 
 TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates"

--- a/kitsune/sumo/anonymous.py
+++ b/kitsune/sumo/anonymous.py
@@ -68,7 +68,7 @@ class AnonymousIdentity(object):
             pid = 1
 
         md5 = hashlib.md5()
-        md5.update('%s%s%s%s' % (
+        md5.update('{0!s}{1!s}{2!s}{3!s}'.format(
             randrange(0, MAX_ANONYMOUS_ID),
             pid, time.time(), settings.SECRET_KEY))
         return md5.hexdigest()

--- a/kitsune/sumo/cron.py
+++ b/kitsune/sumo/cron.py
@@ -48,7 +48,7 @@ def send_postatus_errors():
     # If we have errors to send, send them
     if errordata:
         mail_admins(
-            subject='[SUMO] postatus errors %s' % datestamp,
+            subject='[SUMO] postatus errors {0!s}'.format(datestamp),
             message=(
                 'These are the errors in the SUMO postatus file.\n' +
                 'See http://postatus.paas.allizom.org/p/SUMO for details\n' +

--- a/kitsune/sumo/googleanalytics.py
+++ b/kitsune/sumo/googleanalytics.py
@@ -125,7 +125,7 @@ def pageviews_by_document(start_date, end_date, verbose=False):
             start_date_step = start_date
 
         if verbose:
-            print 'Fetching data for %s to %s:' % (start_date_step,
+            print 'Fetching data for {0!s} to {1!s}:'.format(start_date_step,
                                                    end_date_step)
 
         start_index = 1
@@ -151,7 +151,7 @@ def pageviews_by_document(start_date, end_date, verbose=False):
                 d = (max_results - 1
                      if start_index + max_results - 1 < results['totalResults']
                      else results['totalResults'] - start_index)
-                print '- Got %s of %s results.' % (start_index + d,
+                print '- Got {0!s} of {1!s} results.'.format(start_index + d,
                                                    results['totalResults'])
 
             for result in results.get('rows', []):
@@ -198,7 +198,7 @@ def pageviews_by_question(start_date, end_date, verbose=False):
             start_date_step = start_date
 
         if verbose:
-            print 'Fetching data for %s to %s:' % (start_date_step,
+            print 'Fetching data for {0!s} to {1!s}:'.format(start_date_step,
                                                    end_date_step)
 
         start_index = 1
@@ -223,7 +223,7 @@ def pageviews_by_question(start_date, end_date, verbose=False):
                 d = (max_results - 1
                      if start_index + max_results - 1 < results['totalResults']
                      else results['totalResults'] - start_index)
-                print '- Got %s of %s results.' % (start_index + d,
+                print '- Got {0!s} of {1!s} results.'.format(start_index + d,
                                                    results['totalResults'])
 
             for result in results['rows']:

--- a/kitsune/sumo/helpers.py
+++ b/kitsune/sumo/helpers.py
@@ -267,8 +267,7 @@ def datetimeformat(context, value, format='shortdatetime'):
         # Unknown format
         raise DateTimeFormatError
 
-    return jinja2.Markup('<time datetime="%s">%s</time>' %
-                         (convert_value.isoformat(), formatted))
+    return jinja2.Markup('<time datetime="{0!s}">{1!s}</time>'.format(convert_value.isoformat(), formatted))
 
 
 _whitespace_then_break = re.compile(r'[\r\n\t ]+[\r\n]+')

--- a/kitsune/sumo/management/commands/extract_db.py
+++ b/kitsune/sumo/management/commands/extract_db.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
                     for i in range(len(attrs)):
                         msg = {
                             'id': strip_whitespace(item[i]),
-                            'context': 'DB: %s.%s.%s' % (app, model, attrs[i]),
+                            'context': 'DB: {0!s}.{1!s}.{2!s}'.format(app, model, attrs[i]),
                             'comments': params.get('comments')}
                         strings.append(msg)
 

--- a/kitsune/sumo/management/commands/nunjucks_precompile.py
+++ b/kitsune/sumo/management/commands/nunjucks_precompile.py
@@ -32,8 +32,8 @@ class Command(BaseCommand):
         for f in files:
             if f.endswith('.html'):
                 tpl = f[:-5]
-                cmd = '%s %s > %s' % (
+                cmd = '{0!s} {1!s} > {2!s}'.format(
                     settings.NUNJUCKS_PRECOMPILE_BIN,
                     path('static/sumo/tpl'),
-                    path('static/sumo/js/templates/%s.js' % tpl))
+                    path('static/sumo/js/templates/{0!s}.js'.format(tpl)))
                 subprocess.call(cmd, shell=True)

--- a/kitsune/sumo/middleware.py
+++ b/kitsune/sumo/middleware.py
@@ -56,7 +56,7 @@ class LocaleURLMiddleware(object):
             full_path = urllib.quote(full_path.encode('utf-8'))
 
             if query_string:
-                full_path = '%s?%s' % (full_path, query_string)
+                full_path = '{0!s}?{1!s}'.format(full_path, query_string)
 
             response = HttpResponseRedirect(full_path)
 
@@ -116,10 +116,10 @@ class PlusToSpaceMiddleware(object):
         if p.search(request.path_info):
             new = p.sub(' ', request.path_info)
             if request.META['QUERY_STRING']:
-                new = u'%s?%s' % (new,
+                new = u'{0!s}?{1!s}'.format(new,
                                   smart_unicode(request.META['QUERY_STRING']))
             if hasattr(request, 'LANGUAGE_CODE'):
-                new = u'/%s%s' % (request.LANGUAGE_CODE, new)
+                new = u'/{0!s}{1!s}'.format(request.LANGUAGE_CODE, new)
             return HttpResponsePermanentRedirect(new)
 
 

--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -283,7 +283,7 @@ class WikiParser(Parser):
         if title == '' and hash != '':
             if not text:
                 text = hash.replace('_', ' ')
-            return u'<a href="%s">%s</a>' % (hash, text)
+            return u'<a href="{0!s}">{1!s}</a>'.format(hash, text)
 
         link = _get_wiki_link(title, self.locale)
         extra_a_attr = ''

--- a/kitsune/sumo/tests/__init__.py
+++ b/kitsune/sumo/tests/__init__.py
@@ -79,7 +79,7 @@ def attrs_eq(received, **expected):
 
 def starts_with(text, substring):
     """Assert `text` starts with `substring`."""
-    assert text.startswith(substring), "%r doesn't start with %r" % (text,
+    assert text.startswith(substring), "{0!r} doesn't start with {1!r}".format(text,
                                                                      substring)
 
 
@@ -107,7 +107,7 @@ class LocalizingClient(Client):
         path = request.get('PATH_INFO', self.defaults.get('PATH_INFO', '/'))
         locale, shortened = split_path(path)
         if not locale:
-            request['PATH_INFO'] = '/%s/%s' % (settings.LANGUAGE_CODE,
+            request['PATH_INFO'] = '/{0!s}/{1!s}'.format(settings.LANGUAGE_CODE,
                                                shortened)
         return super(LocalizingClient, self).request(**request)
 
@@ -134,8 +134,7 @@ class MigrationTests(TestCase):
             if match:
                 number = match.group()
                 if number in seen_numbers:
-                    self.fail('There is more than one migration #%s in %s.' %
-                              (number, path))
+                    self.fail('There is more than one migration #{0!s} in {1!s}.'.format(number, path))
                 seen_numbers.add(number)
 
     def test_innodb_and_utf8(self):
@@ -228,4 +227,4 @@ def with_save(func):
 def eq_msg(a, b, msg=None):
     """Shorthand for 'assert a == b, "%s %r != %r" % (msg, a, b)'
     """
-    assert a == b, (str(msg) or '') + ' (%r != %r)' % (a, b)
+    assert a == b, (str(msg) or '') + ' ({0!r} != {1!r})'.format(a, b)

--- a/kitsune/sumo/tests/test_googleanalytics.py
+++ b/kitsune/sumo/tests/test_googleanalytics.py
@@ -46,7 +46,7 @@ class GoogleAnalyticsTests(TestCase):
         documents = []
         for i in range(1, 6):
             documents.append(revision(
-                document=document(slug='doc-%s' % i, save=True),
+                document=document(slug='doc-{0!s}'.format(i), save=True),
                 is_approved=True,
                 save=True).document)
 

--- a/kitsune/sumo/tests/test_helpers.py
+++ b/kitsune/sumo/tests/test_helpers.py
@@ -125,10 +125,10 @@ class TestDateTimeFormat(TestCase):
         date_today = datetime.today()
         date_localize = self.timezone.localize(date_today)
         value_returned = unicode(datetimeformat(self.context, date_today))
-        value_expected = 'Today at %s' % format_time(date_localize,
+        value_expected = 'Today at {0!s}'.format(format_time(date_localize,
                                                      format='short',
                                                      locale=self.locale,
-                                                     tzinfo=self.timezone)
+                                                     tzinfo=self.timezone))
         eq_(pq(value_returned)('time').text(), value_expected)
 
     def test_locale(self):

--- a/kitsune/sumo/tests/test_pagination.py
+++ b/kitsune/sumo/tests/test_pagination.py
@@ -12,7 +12,7 @@ from kitsune.sumo.utils import paginate, simple_paginate
 
 def test_paginated_url():
     """Avoid duplicating page param in pagination."""
-    url = '%s?%s' % (reverse('search'), 'q=bookmarks&page=2')
+    url = '{0!s}?{1!s}'.format(reverse('search'), 'q=bookmarks&page=2')
     request = RequestFactory().get(url)
     queryset = [{}, {}]
     paginated = paginate(request, queryset)
@@ -21,7 +21,7 @@ def test_paginated_url():
 
 
 def test_invalid_page_param():
-    url = '%s?%s' % (reverse('search'), 'page=a')
+    url = '{0!s}?{1!s}'.format(reverse('search'), 'page=a')
     request = RequestFactory().get(url)
     queryset = range(100)
     paginated = paginate(request, queryset)
@@ -40,7 +40,7 @@ def test_paginator_filter():
     eq_(11, len(doc('li')))
 
     # Correct number of <li>s in the middle.
-    url = '%s?%s' % (reverse('search'), 'page=10')
+    url = '{0!s}?{1!s}'.format(reverse('search'), 'page=10')
     request = RequestFactory().get(url)
     pager = paginate(request, range(200), per_page=10)
     html = paginator(pager)

--- a/kitsune/sumo/tests/test_parser.py
+++ b/kitsune/sumo/tests/test_parser.py
@@ -222,7 +222,7 @@ class TestWikiParser(TestCase):
                 'https://youtu.be/oHg5SJYRHA0']
 
         for url in urls:
-            doc = pq(self.p.parse('[[V:%s]]' % url))
+            doc = pq(self.p.parse('[[V:{0!s}]]'.format(url)))
             assert doc('iframe')[0].attrib['src'].startswith(
                 '//www.youtube.com/embed/oHg5SJYRHA0')
 
@@ -559,8 +559,7 @@ class TestWikiImageTags(TestCase):
             img = pq_img(self.p, '[[Image:test.jpg|alt=' + alt_sent + ']]')
 
             is_true = str(img).startswith('<img alt="' + alt_expected + '"')
-            assert is_true, ('Expected "%s", sent "%s"' %
-                             (alt_expected, alt_sent))
+            assert is_true, ('Expected "{0!s}", sent "{1!s}"'.format(alt_expected, alt_sent))
 
     def test_width(self):
         """Image width attribute set."""

--- a/kitsune/sumo/tests/test_qunit.py
+++ b/kitsune/sumo/tests/test_qunit.py
@@ -28,7 +28,7 @@ class TestQunit(SeleniumTestCase):
 
         # Print number of test groups so it's more likely we notice problems
         # with this test.
-        print 'QUNIT: examining %d test groups...' % len(test_groups)
+        print 'QUNIT: examining {0:d} test groups...'.format(len(test_groups))
 
         # Go through each test group to see status.
         for group in test_groups:
@@ -55,7 +55,7 @@ class TestQunit(SeleniumTestCase):
                 actual = actuals[0].text if len(actuals) else None
                 expect = expects[0].text if len(expects) else None
 
-                print 'QUNIT FAIL: in "%s": %s != %s' % (title, expect, actual)
+                print 'QUNIT FAIL: in "{0!s}": {1!s} != {2!s}'.format(title, expect, actual)
 
         # Assert we had no failures in the tests.
         eq_(total_fails, 0, 'One or more Qunit tests failed; see output for details')

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -57,7 +57,7 @@ def build_paged_url(request):
 
     qsa = urlencode(items)
 
-    return u'%s?%s' % (base, qsa)
+    return u'{0!s}?{1!s}'.format(base, qsa)
 
 
 # By Ned Batchelder.
@@ -183,7 +183,7 @@ def user_or_ip(key_prefix):
         else:
             key = request.META.get('HTTP_X_CLUSTER_CLIENT_IP',
                                    request.META['REMOTE_ADDR'])
-        return 'uip:%s:%s' % (key_prefix, key)
+        return 'uip:{0!s}:{1!s}'.format(key_prefix, key)
 
     return _user_or_ip
 

--- a/kitsune/sumo/views.py
+++ b/kitsune/sumo/views.py
@@ -136,8 +136,7 @@ def test_memcached(host, port):
         s.connect((host, port))
         return True
     except Exception as exc:
-        log.critical('Failed to connect to memcached (%r): %s' %
-                     ((host, port), exc))
+        log.critical('Failed to connect to memcached ({0!r}): {1!s}'.format((host, port), exc))
         return False
     finally:
         s.close()
@@ -174,7 +173,7 @@ def monitor(request):
                     ip, port = loc.split(':')
                     result = test_memcached(ip, int(port))
                     memcache_results.append(
-                        (INFO, '%s:%s %s' % (ip, port, result)))
+                        (INFO, '{0!s}:{1!s} {2!s}'.format(ip, port, result)))
 
         if not memcache_results:
             memcache_results.append((ERROR, 'memcache is not configured.'))
@@ -189,7 +188,7 @@ def monitor(request):
 
     except Exception as exc:
         memcache_results.append(
-            (ERROR, 'Exception while looking at memcached: %s' % str(exc)))
+            (ERROR, 'Exception while looking at memcached: {0!s}'.format(str(exc))))
 
     status['memcached'] = memcache_results
 
@@ -227,7 +226,7 @@ def monitor(request):
 
         if path_exists and path_perms:
             filepath_results.append(
-                (INFO, '%s: %s %s %s' % (path, path_exists, path_perms,
+                (INFO, '{0!s}: {1!s} {2!s} {3!s}'.format(path, path_exists, path_perms,
                                          notes)))
 
     status['filepaths'] = filepath_results
@@ -241,11 +240,11 @@ def monitor(request):
             (INFO, 'Successfully connected to RabbitMQ.'))
     except (socket.error, IOError) as exc:
         rabbitmq_results.append(
-            (ERROR, 'Error connecting to RabbitMQ: %s' % str(exc)))
+            (ERROR, 'Error connecting to RabbitMQ: {0!s}'.format(str(exc))))
 
     except Exception as exc:
         rabbitmq_results.append(
-            (ERROR, 'Exception while looking at RabbitMQ: %s' % str(exc)))
+            (ERROR, 'Exception while looking at RabbitMQ: {0!s}'.format(str(exc))))
 
     status['RabbitMQ'] = rabbitmq_results
 
@@ -259,11 +258,11 @@ def monitor(request):
 
     except es_utils.ES_EXCEPTIONS as exc:
         es_results.append(
-            (ERROR, 'ElasticSearch problem: %s' % str(exc)))
+            (ERROR, 'ElasticSearch problem: {0!s}'.format(str(exc))))
 
     except Exception as exc:
         es_results.append(
-            (ERROR, 'Exception while looking at ElasticSearch: %s' % str(exc)))
+            (ERROR, 'Exception while looking at ElasticSearch: {0!s}'.format(str(exc))))
 
     status['ElasticSearch'] = es_results
 
@@ -279,9 +278,9 @@ def monitor(request):
         for backend in settings.REDIS_BACKENDS:
             try:
                 redis_client(backend)
-                redis_results.append((INFO, '%s: Pass!' % backend))
+                redis_results.append((INFO, '{0!s}: Pass!'.format(backend)))
             except RedisError:
-                redis_results.append((ERROR, '%s: Fail!' % backend))
+                redis_results.append((ERROR, '{0!s}: Fail!'.format(backend)))
     status['Redis'] = redis_results
 
     status_code = 200

--- a/kitsune/sumo/widgets.py
+++ b/kitsune/sumo/widgets.py
@@ -13,6 +13,5 @@ class ImageWidget(forms.FileInput):
     def render(self, name, value, attrs=None):
         output = super(ImageWidget, self).render(name, value, attrs)
         if value and hasattr(value, 'url'):
-            output = ('<div class="val-wrap"><img src="%s" alt="" />%s</div>' %
-                      (value.url, output))
+            output = ('<div class="val-wrap"><img src="{0!s}" alt="" />{1!s}</div>'.format(value.url, output))
         return output

--- a/kitsune/tags/forms.py
+++ b/kitsune/tags/forms.py
@@ -50,18 +50,17 @@ class TagWidget(Widget):
 
             # Hidden input for form state:
             if not self.async_urls:
-                output += u'<input%s />' % flatatt({
+                output += u'<input{0!s} />'.format(flatatt({
                     'value': force_unicode(tag.name),
                     'type': 'hidden',
-                    'name': control_name})
+                    'name': control_name}))
 
                 # Linkless tag name:
-                output += (u'<span class="tag-name">%s</span>' %
-                           escape(tag.name))
+                output += (u'<span class="tag-name">{0!s}</span>'.format(
+                           escape(tag.name)))
             else:
                 # Anchor for link to by-tag view:
-                output += (u'<a class="tag-name" href="%s">%s</a>' %
-                           (escape(self.make_link(tag.slug)),
+                output += (u'<a class="tag-name" href="{0!s}">{1!s}</a>'.format(escape(self.make_link(tag.slug)),
                             escape(tag.name)))
 
             # Remove button:
@@ -80,11 +79,11 @@ class TagWidget(Widget):
 
     def render(self, name, value, attrs=None):
         """Render a hidden input for each choice plus a blank text input."""
-        output = u'<div class="tag-adder tags%s"' % (
-            '' if self.read_only or self.async_urls else ' deferred')
+        output = u'<div class="tag-adder tags{0!s}"'.format((
+            '' if self.read_only or self.async_urls else ' deferred'))
         if not self.read_only:
             vocab = [t.name for t in Tag.objects.only('name').all()]
-            output += u' data-tag-vocab-json="%s"' % escape(json.dumps(vocab))
+            output += u' data-tag-vocab-json="{0!s}"'.format(escape(json.dumps(vocab)))
         if self.can_create_tags:
             output += u' data-can-create-tags="1"'
         output += u'>'
@@ -114,12 +113,12 @@ class TagWidget(Widget):
             # the hidden inputs, it should handily work as a JS-less fallback.
             input_attrs = self.build_attrs(attrs, type='text', name=name,
                                            **{'class': 'autocomplete-tags'})
-            output += u'<input%s />' % flatatt(input_attrs)
+            output += u'<input{0!s} />'.format(flatatt(input_attrs))
 
             # Add the Add button:
-            output += u'<input%s />' % flatatt(dict(type='submit',
+            output += u'<input{0!s} />'.format(flatatt(dict(type='submit',
                                                     value=_('Add'),
-                                                    **{'class': 'adder'}))
+                                                    **{'class': 'adder'})))
 
         output += u'</div>'
         return mark_safe(output)

--- a/kitsune/twitter/__init__.py
+++ b/kitsune/twitter/__init__.py
@@ -25,7 +25,7 @@ def url(request, override=None):
     if override:
         d.update(override)
 
-    return u'%s://%s%s' % (d['scheme'], d['host'], d['path'])
+    return u'{0!s}://{1!s}{2!s}'.format(d['scheme'], d['host'], d['path'])
 
 
 def auth_wanted(view_func):

--- a/kitsune/upload/storage.py
+++ b/kitsune/upload/storage.py
@@ -26,7 +26,6 @@ class RenameFileStorage(DjangoStorage):
         count = itertools.count(1)
         while self.exists(name):
             # file_ext includes the dot.
-            name = os.path.join(dir_name, "%s_%s%s" %
-                                (file_root, count.next(), file_ext))
+            name = os.path.join(dir_name, "{0!s}_{1!s}{2!s}".format(file_root, count.next(), file_ext))
 
         return name

--- a/kitsune/upload/tests/__init__.py
+++ b/kitsune/upload/tests/__init__.py
@@ -76,7 +76,7 @@ class CreateImageAttachmentTestCase(TestCase):
 class FileNameTestCase(TestCase):
     def _match_file_name(self, name, name_end):
         assert name.endswith(name_end), (
-            '"%s" does not end with "%s"' % (name, name_end))
+            '"{0!s}" does not end with "{1!s}"'.format(name, name_end))
 
     def test_empty_file_name(self):
         self._match_file_name('', '')

--- a/kitsune/upload/tests/test_views.py
+++ b/kitsune/upload/tests/test_views.py
@@ -70,7 +70,7 @@ class UploadImageTestCase(TestCase):
         eq_(90, file['width'])
         eq_(120, file['height'])
         name = '098f6b.png'
-        message = 'Url "%s" does not contain "%s"' % (file['url'], name)
+        message = 'Url "{0!s}" does not contain "{1!s}"'.format(file['url'], name)
         assert (name in file['url']), message
 
         eq_(1, ImageAttachment.objects.count())

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -91,6 +91,6 @@ if settings.DEBUG:
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += patterns(
         '',
-        (r'^%s/(?P<path>.*)$' % media_url, 'kitsune.sumo.views.serve_cors',
+        (r'^{0!s}/(?P<path>.*)$'.format(media_url), 'kitsune.sumo.views.serve_cors',
          {'document_root': settings.MEDIA_ROOT}),
     )

--- a/kitsune/users/admin.py
+++ b/kitsune/users/admin.py
@@ -43,7 +43,7 @@ class ProfileAdmin(admin.ModelAdmin):
 
     def full_user(self, obj):
         if obj.name:
-            return u'%s <%s>' % (obj.user.username, obj.name)
+            return u'{0!s} <{1!s}>'.format(obj.user.username, obj.name)
         else:
             return obj.user.username
     full_user.short_description = 'User'

--- a/kitsune/users/hashers.py
+++ b/kitsune/users/hashers.py
@@ -17,7 +17,7 @@ class SHA256PasswordHasher(BasePasswordHasher):
         assert salt and '$' not in salt
         hash = hashlib.sha256(
             smart_str(salt) + smart_str(password)).hexdigest()
-        return "%s$%s$%s" % (self.algorithm, salt, hash)
+        return "{0!s}${1!s}${2!s}".format(self.algorithm, salt, hash)
 
     def verify(self, password, encoded):
         algorithm, salt, hash = encoded.split('$', 2)

--- a/kitsune/users/helpers.py
+++ b/kitsune/users/helpers.py
@@ -41,19 +41,19 @@ def profile_avatar(user, size=48):
                   settings.STATIC_URL + settings.DEFAULT_AVATAR)
 
     if avatar.startswith('//'):
-        avatar = 'https:%s' % avatar
+        avatar = 'https:{0!s}'.format(avatar)
 
     if user and hasattr(user, 'email'):
         email_hash = hashlib.md5(force_str(user.email.lower())).hexdigest()
     else:
         email_hash = '00000000000000000000000000000000'
 
-    url = 'https://secure.gravatar.com/avatar/%s?s=%s' % (email_hash, size)
+    url = 'https://secure.gravatar.com/avatar/{0!s}?s={1!s}'.format(email_hash, size)
 
     # If the url doesn't start with http (local dev), don't pass it to
     # to gravatar because it can't use it.
     if avatar.startswith('http'):
-        url = url + '&d=%s' % urllib.quote(avatar)
+        url = url + '&d={0!s}'.format(urllib.quote(avatar))
 
     return url
 
@@ -71,12 +71,12 @@ def display_name(user):
 @register.filter
 def public_email(email):
     """Email address -> publicly displayable email."""
-    return Markup('<span class="email">%s</span>' % unicode_to_html(email))
+    return Markup('<span class="email">{0!s}</span>'.format(unicode_to_html(email)))
 
 
 def unicode_to_html(text):
     """Turns all unicode into html entities, e.g. &#69; -> E."""
-    return ''.join([u'&#%s;' % ord(i) for i in text])
+    return ''.join([u'&#{0!s};'.format(ord(i)) for i in text])
 
 
 @register.function

--- a/kitsune/users/management/commands/purge_hashes.py
+++ b/kitsune/users/management/commands/purge_hashes.py
@@ -16,4 +16,4 @@ class Command(BaseCommand):
             user.set_unusable_password()
             user.save()
 
-        print 'Cleared %d passwords.' % len(users)
+        print 'Cleared {0:d} passwords.'.format(len(users))

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -83,7 +83,7 @@ class Profile(ModelBase, SearchMixin):
         try:
             return unicode(self.user)
         except Exception as exc:
-            return unicode('%d (%r)' % (self.pk, exc))
+            return unicode('{0:d} ({1!r})'.format(self.pk, exc))
 
     def get_absolute_url(self):
         return reverse('users.profile', args=[self.user_id])
@@ -329,7 +329,7 @@ class Setting(ModelBase):
         unique_together = (('user', 'name'),)
 
     def __unicode__(self):
-        return u'%s %s:%s' % (self.user, self.name, self.value or u'[none]')
+        return u'{0!s} {1!s}:{2!s}'.format(self.user, self.name, self.value or u'[none]')
 
     @classmethod
     def get_for_user(cls, user, name):
@@ -590,7 +590,7 @@ class RegistrationProfile(models.Model):
         verbose_name_plural = _lazy(u'registration profiles')
 
     def __unicode__(self):
-        return u'Registration information for %s' % self.user
+        return u'Registration information for {0!s}'.format(self.user)
 
     def activation_key_expired(self):
         """
@@ -624,7 +624,7 @@ class EmailChange(models.Model):
     objects = EmailChangeManager()
 
     def __unicode__(self):
-        return u'Change email request to %s for %s' % (self.email, self.user)
+        return u'Change email request to {0!s} for {1!s}'.format(self.email, self.user)
 
 
 class Deactivation(models.Model):
@@ -636,5 +636,5 @@ class Deactivation(models.Model):
     date = models.DateTimeField(default=datetime.now)
 
     def __unicode__(self):
-        return u'%s was deactivated by %s on %s' % (self.user, self.moderator,
+        return u'{0!s} was deactivated by {1!s} on {2!s}'.format(self.user, self.moderator,
                                                     self.date)

--- a/kitsune/users/monkeypatch.py
+++ b/kitsune/users/monkeypatch.py
@@ -6,14 +6,14 @@ from kitsune.sumo.urlresolvers import reverse
 
 def _activate_users(admin, request, qs):
     num = qs.update(is_active=True)
-    msg = '%s users activated.' % num if num != 1 else 'One user activated.'
+    msg = '{0!s} users activated.'.format(num) if num != 1 else 'One user activated.'
     admin.message_user(request, msg)
 _activate_users.short_description = u'Activate selected users'
 
 
 def _deactivate_users(admin, request, qs):
     num = qs.update(is_active=False)
-    msg = ('%s users deactivated.' % num if num != 1 else
+    msg = ('{0!s} users deactivated.'.format(num) if num != 1 else
            'One user deactivated.')
     admin.message_user(request, msg)
 _deactivate_users.short_description = u'Deactivate selected users'

--- a/kitsune/users/tests/test_helpers.py
+++ b/kitsune/users/tests/test_helpers.py
@@ -19,26 +19,26 @@ class HelperTestCase(TestCase):
         self.u = user(username=u'testuser', save=True)
 
     def test_profile_url(self):
-        eq_(u'/user/%s' % self.u.username, profile_url(self.u))
+        eq_(u'/user/{0!s}'.format(self.u.username), profile_url(self.u))
 
     def test_profile_avatar_default(self):
         profile(user=self.u)
         email_hash = hashlib.md5(self.u.email.lower()).hexdigest()
-        gravatar_url = 'https://secure.gravatar.com/avatar/%s?s=48' % (
-            email_hash)
+        gravatar_url = 'https://secure.gravatar.com/avatar/{0!s}?s=48'.format((
+            email_hash))
         assert profile_avatar(self.u).startswith(gravatar_url)
 
     def test_profile_avatar_anonymous(self):
         email_hash = '00000000000000000000000000000000'
-        gravatar_url = 'https://secure.gravatar.com/avatar/%s?s=48' % (
-            email_hash)
+        gravatar_url = 'https://secure.gravatar.com/avatar/{0!s}?s=48'.format((
+            email_hash))
         assert profile_avatar(AnonymousUser()).startswith(gravatar_url)
 
     def test_profile_avatar(self):
         profile(user=self.u, avatar='images/foo.png')
         email_hash = hashlib.md5(self.u.email.lower()).hexdigest()
-        gravatar_url = 'https://secure.gravatar.com/avatar/%s?s=48' % (
-            email_hash)
+        gravatar_url = 'https://secure.gravatar.com/avatar/{0!s}?s=48'.format((
+            email_hash))
         assert profile_avatar(self.u).startswith(gravatar_url)
 
     def test_profile_avatar_unicode(self):

--- a/kitsune/users/tests/test_templates.py
+++ b/kitsune/users/tests/test_templates.py
@@ -194,7 +194,7 @@ class PasswordResetTests(TestCaseBase):
         eq_('http://testserver/en-US/users/pwresetsent', r['location'])
         eq_(1, len(mail.outbox))
         assert mail.outbox[0].subject.find('Password reset') == 0
-        assert mail.outbox[0].body.find('pwreset/%s' % self.uidb36) > 0
+        assert mail.outbox[0].body.find('pwreset/{0!s}'.format(self.uidb36)) > 0
 
     @mock.patch.object(PasswordResetForm, 'save')
     def test_smtp_error(self, pwform_save):
@@ -412,7 +412,7 @@ class ViewProfileTests(TestCaseBase):
         # No name set => no optional fields.
         eq_(0, doc('.contact').length)
         # Check canonical url
-        eq_('/user/%s' % self.u.username,
+        eq_('/user/{0!s}'.format(self.u.username),
             doc('link[rel="canonical"]')[0].attrib['href'])
 
     def test_view_profile_mine(self):
@@ -639,6 +639,6 @@ class EditWatchListTests(TestCaseBase):
         eq_(w.is_active, False)
 
         self.client.post(reverse('users.edit_watch_list'), {
-            'watch_%s' % w.id: '1'})
+            'watch_{0!s}'.format(w.id): '1'})
         w = Watch.objects.get(object_id=self.question.id, user=self.user)
         eq_(w.is_active, True)

--- a/kitsune/users/tests/test_views.py
+++ b/kitsune/users/tests/test_views.py
@@ -44,7 +44,7 @@ class RegisterTests(TestCase):
         eq_(1, len(mail.outbox))
         assert mail.outbox[0].subject.find('Please confirm your') == 0
         key = RegistrationProfile.objects.all()[0].activation_key
-        assert mail.outbox[0].body.find('activate/%s/%s' % (u.id, key)) > 0
+        assert mail.outbox[0].body.find('activate/{0!s}/{1!s}'.format(u.id, key)) > 0
 
         # By default, users aren't added to any groups
         eq_(0, len(u.groups.all()))
@@ -328,7 +328,7 @@ class ChangeEmailTestCase(TestCase):
                                            args=[ec.activation_key]))
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('Unable to change email for user %s' % self.u.username,
+        eq_('Unable to change email for user {0!s}'.format(self.u.username),
             doc('article h1').text())
         u = User.objects.get(username=self.u.username)
         eq_(old_email, u.email)

--- a/kitsune/users/utils.py
+++ b/kitsune/users/utils.py
@@ -73,7 +73,7 @@ def try_send_email_with_form(func, form, field_name, *args, **kwargs):
     try:
         func(*args, **kwargs)
     except SMTPException as e:
-        log.warning(u'Failed to send email: %s' % e)
+        log.warning(u'Failed to send email: {0!s}'.format(e))
         if 'email' not in form.errors:
             form.errors[field_name] = []
         form.errors[field_name].append(unicode(ERROR_SEND_EMAIL))

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -344,8 +344,8 @@ def close_account(request):
     profile.save()
 
     # Deactivate the user and change key information
-    request.user.username = 'user%s' % request.user.id
-    request.user.email = '%s@example.com' % request.user.id
+    request.user.username = 'user{0!s}'.format(request.user.id)
+    request.user.email = '{0!s}@example.com'.format(request.user.id)
     request.user.is_active = False
 
     # Remove from all groups
@@ -441,7 +441,7 @@ def edit_watch_list(request):
 
     if request.method == 'POST':
         for w in watch_list:
-            w.is_active = 'watch_%s' % w.id in request.POST
+            w.is_active = 'watch_{0!s}'.format(w.id) in request.POST
             w.save()
 
     return render(request, 'users/edit_watches.html', {

--- a/kitsune/wiki/admin.py
+++ b/kitsune/wiki/admin.py
@@ -36,7 +36,7 @@ class DocumentAdmin(admin.ModelAdmin):
             if count == 1 else
             'documents, along with their English versions or translations, '
             'were marked as ')
-        self.message_user(request, '%s %s %s.' % (count, phrase, verb))
+        self.message_user(request, '{0!s} {1!s} {2!s}.'.format(count, phrase, verb))
 
     def archive(self, request, queryset):
         """Mark several documents as obsolete."""

--- a/kitsune/wiki/cron.py
+++ b/kitsune/wiki/cron.py
@@ -63,7 +63,7 @@ def send_weekly_ready_for_review_digest():
 
     @email_utils.safe_translation
     def _send_mail(locale, user, context):
-        subject = _('[Reviews Pending: %s] SUMO needs your help!' % locale)
+        subject = _('[Reviews Pending: {0!s}] SUMO needs your help!'.format(locale))
 
         mail = email_utils.make_mail(
             subject=subject,

--- a/kitsune/wiki/diff.py
+++ b/kitsune/wiki/diff.py
@@ -31,8 +31,8 @@ class BetterHtmlDiff(difflib.HtmlDiff):
         text -- line text to be marked up
         """
         try:
-            linenum = '%d' % linenum
-            id = ' id="%s%s"' % (self._prefix[side], linenum)
+            linenum = '{0:d}'.format(linenum)
+            id = ' id="{0!s}{1!s}"'.format(self._prefix[side], linenum)
         except TypeError:
             # handle blank lines where linenum is '>' or ''
             id = ''
@@ -42,5 +42,4 @@ class BetterHtmlDiff(difflib.HtmlDiff):
 
         text = text.replace('  ', '&nbsp; ').rstrip()
 
-        return '<td class="diff_header"%s>%s</td><td class="text">%s</td>' \
-               % (id, linenum, text)
+        return '<td class="diff_header"{0!s}>{1!s}</td><td class="text">{2!s}</td>'.format(id, linenum, text)

--- a/kitsune/wiki/events.py
+++ b/kitsune/wiki/events.py
@@ -28,10 +28,10 @@ def context_dict(revision, ready_for_l10n=False, revision_approved=False):
     l10n = revision.document.revisions.filter(is_ready_for_localization=True)
     approved = revision.document.revisions.filter(is_approved=True)
     if ready_for_l10n and l10n.count() > 1:
-        fromfile = u'[%s] %s #%s' % (revision.document.locale,
+        fromfile = u'[{0!s}] {1!s} #{2!s}'.format(revision.document.locale,
                                      revision.document.title,
                                      l10n.order_by('-created')[1].id)
-        tofile = u'[%s] %s #%s' % (revision.document.locale,
+        tofile = u'[{0!s}] {1!s} #{2!s}'.format(revision.document.locale,
                                    revision.document.title,
                                    revision.id)
 
@@ -46,8 +46,8 @@ def context_dict(revision, ready_for_l10n=False, revision_approved=False):
         doc = revision.document
         approved_rev = approved.order_by('-created')[1]
 
-        fromfile = u'[%s] %s #%s' % (doc.locale, doc.title, approved_rev.id)
-        tofile = u'[%s] %s #%s' % (doc.locale, doc.title, revision.id)
+        fromfile = u'[{0!s}] {1!s} #{2!s}'.format(doc.locale, doc.title, approved_rev.id)
+        tofile = u'[{0!s}] {1!s} #{2!s}'.format(doc.locale, doc.title, revision.id)
 
         diff = clean(
             u''.join(
@@ -57,10 +57,10 @@ def context_dict(revision, ready_for_l10n=False, revision_approved=False):
                     fromfile=fromfile, tofile=tofile)),
             ALLOWED_TAGS, ALLOWED_ATTRIBUTES)
     elif revision.document.current_revision is not None:
-        fromfile = u'[%s] %s #%s' % (revision.document.locale,
+        fromfile = u'[{0!s}] {1!s} #{2!s}'.format(revision.document.locale,
                                      revision.document.title,
                                      revision.document.current_revision.id)
-        tofile = u'[%s] %s #%s' % (revision.document.locale,
+        tofile = u'[{0!s}] {1!s} #{2!s}'.format(revision.document.locale,
                                    revision.document.title,
                                    revision.id)
 
@@ -94,8 +94,8 @@ class EditDocumentEvent(InstanceEvent):
     def _mails(self, users_and_watches):
         revision = self.revision
         document = revision.document
-        log.debug('Sending edited notification email for document (id=%s)' %
-                  document.id)
+        log.debug('Sending edited notification email for document (id={0!s})'.format(
+                  document.id))
 
         subject = _lazy(u'{title} was edited by {creator}')
         url = reverse('wiki.document_revisions', locale=document.locale,
@@ -207,8 +207,8 @@ class ReviewableRevisionInLocaleEvent(_RevisionConstructor,
     def _mails(self, users_and_watches):
         revision = self.revision
         document = revision.document
-        log.debug('Sending ready for review email for revision (id=%s)' %
-                  revision.id)
+        log.debug('Sending ready for review email for revision (id={0!s})'.format(
+                  revision.id))
         subject = _lazy(u'{title} is ready for review ({creator})')
         url = reverse('wiki.review_revision',
                       locale=document.locale,
@@ -238,8 +238,8 @@ class ReadyRevisionEvent(_RevisionConstructor, _ProductFilter, Event):
         """Send readiness mails."""
         revision = self.revision
         document = revision.document
-        log.debug('Sending ready notifications for revision (id=%s)' %
-                  revision.id)
+        log.debug('Sending ready notifications for revision (id={0!s})'.format(
+                  revision.id))
 
         subject = _lazy(u'{title} has a revision ready for localization')
 
@@ -291,8 +291,8 @@ class ApprovedOrReadyUnion(EventUnion):
         revision = self._revision
         document = revision.document
         is_ready = revision.is_ready_for_localization
-        log.debug('Sending approved/ready notifications for revision (id=%s)' %
-                  revision.id)
+        log.debug('Sending approved/ready notifications for revision (id={0!s})'.format(
+                  revision.id))
 
         # Localize the subject and message with the appropriate
         # context. If there is an error, fall back to English.

--- a/kitsune/wiki/facets.py
+++ b/kitsune/wiki/facets.py
@@ -155,4 +155,4 @@ def _documents_for_cache_key(locale, topics, products):
         products=','.join(sorted([p.slug for p in products or []])))
 
     m.update(key)
-    return 'documents_for:%s' % m.hexdigest()
+    return 'documents_for:{0!s}'.format(m.hexdigest())

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -181,7 +181,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
 
         # Can't save this translation if parent not localizable
         if self.parent and not self.parent.is_localizable:
-            raise ValidationError('"%s": parent "%s" is not localizable.' % (
+            raise ValidationError('"{0!s}": parent "{1!s}" is not localizable.'.format(
                                   unicode(self), unicode(self.parent)))
 
         # Can't make not localizable if it has translations
@@ -434,7 +434,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             return self.from_url(url)
 
     def __unicode__(self):
-        return '[%s] %s' % (self.locale, self.title)
+        return '[{0!s}] {1!s}'.format(self.locale, self.title)
 
     def allows_vote(self, request):
         """Return whether we should render the vote form for the document."""
@@ -972,7 +972,7 @@ class Revision(ModelBase, SearchMixin):
         return qs.exists()
 
     def __unicode__(self):
-        return u'[%s] %s #%s: %s' % (self.document.locale,
+        return u'[{0!s}] {1!s} #{2!s}: {3!s}'.format(self.document.locale,
                                      self.document.title,
                                      self.id, self.content[:50])
 
@@ -1155,8 +1155,7 @@ class DocumentLink(ModelBase):
         unique_together = ('linked_from', 'linked_to', 'kind')
 
     def __unicode__(self):
-        return (u'<DocumentLink: %s from %r to %r>' %
-                (self.kind, self.linked_from, self.linked_to))
+        return (u'<DocumentLink: {0!s} from {1!r} to {2!r}>'.format(self.kind, self.linked_from, self.linked_to))
 
 
 class DocumentImage(ModelBase):

--- a/kitsune/wiki/parser.py
+++ b/kitsune/wiki/parser.py
@@ -90,7 +90,7 @@ def _key_split(matchobj):
 
     """
     keys = [k.strip() for k in matchobj.group(1).split('+')]
-    return ' + '.join(['<span class="key">%s</span>' % key for key in keys])
+    return ' + '.join(['<span class="key">{0!s}</span>'.format(key) for key in keys])
 
 
 PATTERNS = [
@@ -248,7 +248,7 @@ class ForParser(object):
             if tag != '{/for}':
                 i = indexes.next()
                 dehydrations[i] = cls._wiki_to_tag(attrs)
-                token = u'\x07%i\x07' % i
+                token = u'\x07{0:d}\x07'.format(i)
             else:
                 token = u'\x07/sf\x07'
 

--- a/kitsune/wiki/permissions.py
+++ b/kitsune/wiki/permissions.py
@@ -16,7 +16,7 @@ class DocumentPermissionMixin(object):
         """Check if the user has the permission on the document."""
 
         # If this is kicking up a KeyError it's probably because you typoed!
-        return getattr(self, '_allows_%s' % action)(user)
+        return getattr(self, '_allows_{0!s}'.format(action))(user)
 
     def _allows_create_revision(self, user):
         """Can the user create a revision for the document?"""
@@ -109,7 +109,7 @@ def _is_leader(locale, user):
     try:
         locale_team = Locale.objects.get(locale=locale)
     except Locale.DoesNotExist:
-        log.warning('Locale not created for %s' % locale)
+        log.warning('Locale not created for {0!s}'.format(locale))
         return False
 
     return user in locale_team.leaders.all()
@@ -125,7 +125,7 @@ def _is_reviewer(locale, user):
     try:
         locale_team = Locale.objects.get(locale=locale)
     except Locale.DoesNotExist:
-        log.warning('Locale not created for %s' % locale)
+        log.warning('Locale not created for {0!s}'.format(locale))
         return False
 
     return user in locale_team.reviewers.all()

--- a/kitsune/wiki/sampledata.py
+++ b/kitsune/wiki/sampledata.py
@@ -93,8 +93,8 @@ def generate_sampledata(options):
     # Generate 9 sample documents with 2 topics each
     topics = list(Topic.objects.all())
     for i in xrange(9):
-        d = document(title='Sample Article %s' % str(i + 1),
-                     slug='sample-article-%s' % str(i + 1), save=True)
+        d = document(title='Sample Article {0!s}'.format(str(i + 1)),
+                     slug='sample-article-{0!s}'.format(str(i + 1)), save=True)
         revision(document=d, is_approved=True, reviewed=datetime.now(),
                  save=True)
         d.products.add(firefox)

--- a/kitsune/wiki/tasks.py
+++ b/kitsune/wiki/tasks.py
@@ -35,11 +35,11 @@ log = logging.getLogger('k.task')
 def send_reviewed_notification(revision, document, message):
     """Send notification of review to the revision creator."""
     if revision.reviewer == revision.creator:
-        log.debug('Revision (id=%s) reviewed by creator, skipping email' %
-                  revision.id)
+        log.debug('Revision (id={0!s}) reviewed by creator, skipping email'.format(
+                  revision.id))
         return
 
-    log.debug('Sending reviewed email for revision (id=%s)' % revision.id)
+    log.debug('Sending reviewed email for revision (id={0!s})'.format(revision.id))
 
     url = reverse('wiki.document_revisions', locale=document.locale,
                   args=[document.slug])
@@ -197,7 +197,7 @@ def _rebuild_kb_chunk(data):
     redirects won't be auto-pruned when they're 404s.
 
     """
-    log.info('Rebuilding %s documents.' % len(data))
+    log.info('Rebuilding {0!s} documents.'.format(len(data)))
 
     pin_this_thread()  # Stick to master.
 
@@ -213,7 +213,7 @@ def _rebuild_kb_chunk(data):
             url = document.redirect_url()
             if (url and points_to_document_view(url) and
                     not document.redirect_document()):
-                log.warn('Invalid redirect document: %d' % pk)
+                log.warn('Invalid redirect document: {0:d}'.format(pk))
 
             html = document.parse_and_calculate_links()
             if document.html != html:
@@ -226,15 +226,15 @@ def _rebuild_kb_chunk(data):
             else:
                 statsd.incr('wiki.rebuild_chunk.nochange')
         except Document.DoesNotExist:
-            message = 'Missing document: %d' % pk
+            message = 'Missing document: {0:d}'.format(pk)
         except Revision.DoesNotExist:
-            message = 'Missing revision for document: %d' % pk
+            message = 'Missing revision for document: {0:d}'.format(pk)
         except ValidationError as e:
-            message = 'ValidationError for %d: %s' % (pk, e.messages[0])
+            message = 'ValidationError for {0:d}: {1!s}'.format(pk, e.messages[0])
         except SlugCollision:
-            message = 'SlugCollision: %d' % pk
+            message = 'SlugCollision: {0:d}'.format(pk)
         except TitleCollision:
-            message = 'TitleCollision: %d' % pk
+            message = 'TitleCollision: {0:d}'.format(pk)
 
         if message:
             log.debug(message)
@@ -243,8 +243,8 @@ def _rebuild_kb_chunk(data):
     statsd.timing('wiki.rebuild_chunk', int(round(d * 1000)))
 
     if messages:
-        subject = ('[%s] Exceptions raised in _rebuild_kb_chunk()' %
-                   settings.PLATFORM_NAME)
+        subject = ('[{0!s}] Exceptions raised in _rebuild_kb_chunk()'.format(
+                   settings.PLATFORM_NAME))
         mail_admins(subject=subject, message='\n'.join(messages))
     transaction.commit_unless_managed()
 

--- a/kitsune/wiki/tests/test_models.py
+++ b/kitsune/wiki/tests/test_models.py
@@ -29,7 +29,7 @@ def _objects_eq(manager, list_):
 def redirect_rev(title, redirect_to):
     return revision(
         document=document(title=title, save=True),
-        content='REDIRECT [[%s]]' % redirect_to,
+        content='REDIRECT [[{0!s}]]'.format(redirect_to),
         is_approved=True,
         save=True)
 
@@ -282,7 +282,7 @@ class DocumentTests(TestCase):
 
         redirector = revision(
             document=document(title=title2, locale='es', save=True),
-            content=u'REDIRECT [[%s]]' % redirect_to.document.title,
+            content=u'REDIRECT [[{0!s}]]'.format(redirect_to.document.title),
             is_approved=True,
             save=True)
 
@@ -536,7 +536,7 @@ class RevisionTests(TestCase):
         d, _ = doc_rev('Replace document html')
 
         assert 'Replace document html' in d.html, \
-               '"Replace document html" not in %s' % d.html
+               '"Replace document html" not in {0!s}'.format(d.html)
 
         # Creating another approved revision replaces it again
         r = revision(document=d, content='Replace html again',
@@ -544,19 +544,19 @@ class RevisionTests(TestCase):
         r.save()
 
         assert 'Replace html again' in d.html, \
-               '"Replace html again" not in %s' % d.html
+               '"Replace html again" not in {0!s}'.format(d.html)
 
     def test_unapproved_revision_not_updates_html(self):
         """Creating an unapproved revision does not update document.html"""
         d, _ = doc_rev('Here to stay')
 
-        assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
+        assert 'Here to stay' in d.html, '"Here to stay" not in {0!s}'.format(d.html)
 
         # Creating another approved revision keeps initial content
         r = revision(document=d, content='Fail to replace html')
         r.save()
 
-        assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
+        assert 'Here to stay' in d.html, '"Here to stay" not in {0!s}'.format(d.html)
 
     def test_revision_unicode(self):
         """Revision containing unicode characters is saved successfully."""

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -121,7 +121,7 @@ class SimpleSyntaxTestCase(TestCase):
         p = WikiParser()
         tags = ['menu', 'button', 'filepath', 'pref']
         for tag in tags:
-            doc = pq(p.parse('{%s this is a %s}' % (tag, tag)))
+            doc = pq(p.parse('{{{0!s} this is a {1!s}}}'.format(tag, tag)))
             eq_('this is a ' + tag, doc('span.' + tag).text())
 
     def test_general_warning_note_inline_custom(self):
@@ -169,10 +169,10 @@ class SimpleSyntaxTestCase(TestCase):
         redirect = Document.objects.get(slug=old_slug)
 
         # Both internal links should link to the same article
-        eq_(p.parse('[[%s]]' % doc.title),
-            '<p><a href="/en-US/kb/%s">%s</a>\n</p>' % (doc.slug, doc.title))
-        eq_(p.parse('[[%s]]' % redirect.title),
-            '<p><a href="/en-US/kb/%s">%s</a>\n</p>' % (doc.slug, doc.title))
+        eq_(p.parse('[[{0!s}]]'.format(doc.title)),
+            '<p><a href="/en-US/kb/{0!s}">{1!s}</a>\n</p>'.format(doc.slug, doc.title))
+        eq_(p.parse('[[{0!s}]]'.format(redirect.title)),
+            '<p><a href="/en-US/kb/{0!s}">{1!s}</a>\n</p>'.format(doc.slug, doc.title))
 
 
 class TestWikiTemplate(TestCase):
@@ -347,7 +347,7 @@ class TestWikiTemplate(TestCase):
             revision(document=d, content='Fine [[Template:Boo]] Fellows',
                      is_approved=True).save()
 
-        eq_('<p>Fine %s Fellows\n</p>' % (RECURSION_MESSAGE % 'Template:Boo'),
+        eq_('<p>Fine {0!s} Fellows\n</p>'.format((RECURSION_MESSAGE % 'Template:Boo')),
             d.content_parsed)
 
     def test_indirect_recursion(self):
@@ -361,7 +361,7 @@ class TestWikiTemplate(TestCase):
         revision(document=yah, content='Wooden [[Template:Boo]] Bats',
                  is_approved=True).save()
         recursion_message = RECURSION_MESSAGE % 'Template:Boo'
-        eq_('<p>Paper Wooden %s Bats\n Cups\n</p>' % recursion_message,
+        eq_('<p>Paper Wooden {0!s} Bats\n Cups\n</p>'.format(recursion_message),
             boo.content_parsed)
 
 
@@ -408,7 +408,7 @@ class TestWikiInclude(TestCase):
             revision(document=d, content='Fine [[Include:Boo]] Fellows',
                      is_approved=True).save()
 
-        eq_('<p>Fine %s Fellows\n</p>' % (RECURSION_MESSAGE % 'Boo'),
+        eq_('<p>Fine {0!s} Fellows\n</p>'.format((RECURSION_MESSAGE % 'Boo')),
             d.content_parsed)
 
     def test_indirect_recursion(self):
@@ -425,7 +425,7 @@ class TestWikiInclude(TestCase):
 
         # boo.content_parsed is something like <p>Paper </p><p>Wooden
         # [Recursive inclusion of "Boo"] Bats\n</p> Cups\n<p></p>.
-        eq_('Paper Wooden %s Bats Cups' % recursion_message,
+        eq_('Paper Wooden {0!s} Bats Cups'.format(recursion_message),
             re.sub(r'</?p>|\n', '', boo.content_parsed))
 
 
@@ -487,8 +487,8 @@ class TestWikiVideo(TestCase):
     def test_video_modal(self):
         """Video modal defaults for plcaeholder and text."""
         v = video()
-        replacement = ('<img class="video-thumbnail" src="%s"/>' %
-                       v.thumbnail_url_if_set())
+        replacement = ('<img class="video-thumbnail" src="{0!s}"/>'.format(
+                       v.thumbnail_url_if_set()))
         d, _, p = doc_rev_parser(
             '[[V:Some title|modal]]')
         doc = pq(d.html)
@@ -530,7 +530,7 @@ class TestWikiVideo(TestCase):
         parser = WikiParser()
 
         for url in urls:
-            doc = pq(parser.parse('[[V:%s]]' % url))
+            doc = pq(parser.parse('[[V:{0!s}]]'.format(url)))
             assert doc('iframe')[0].attrib['src'].startswith(
                 '//www.youtube.com/embed/oHg5SJYRHA0')
 

--- a/kitsune/wiki/tests/test_tasks.py
+++ b/kitsune/wiki/tests/test_tasks.py
@@ -130,7 +130,7 @@ class ReviewMailTestCase(TestCaseBase):
 
         # Two emails will be sent, one each for the reviewer and the reviewed.
         eq_(2, len(mail.outbox))
-        eq_('Your revision has been approved: %s' % doc.title,
+        eq_('Your revision has been approved: {0!s}'.format(doc.title),
             mail.outbox[0].subject)
         eq_([rev.creator.email], mail.outbox[0].to)
         eq_(REVIEWED_EMAIL_CONTENT % (
@@ -159,7 +159,7 @@ class ReviewMailTestCase(TestCaseBase):
 
         # Two emails will be sent, one each for the reviewer and the reviewed.
         eq_(2, len(mail.outbox))
-        eq_('Your revision has been approved: %s' % doc.title,
+        eq_('Your revision has been approved: {0!s}'.format(doc.title),
             mail.outbox[0].subject)
 
     @mock.patch.object(Site.objects, 'get_current')
@@ -174,7 +174,7 @@ class ReviewMailTestCase(TestCaseBase):
 
         # Two emails will be sent, one each for the reviewer and the reviewed.
         eq_(2, len(mail.outbox))
-        eq_('Your revision has been approved: %s' % doc.title,
+        eq_('Your revision has been approved: {0!s}'.format(doc.title),
             mail.outbox[0].subject)
         assert '&quot;' not in mail.outbox[0].body
         assert '"All about quotes"' in mail.outbox[0].body

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -160,10 +160,10 @@ def document(request, document_slug, template=None, document=None):
     ga_push = []
     if fallback_reason is not None:
         ga_push.append(['_trackEvent', 'Incomplete L10n', 'Not Localized',
-                        '%s/%s' % (doc.slug, request.LANGUAGE_CODE)])
+                        '{0!s}/{1!s}'.format(doc.slug, request.LANGUAGE_CODE)])
     elif doc.is_outdated():
         ga_push.append(['_trackEvent', 'Incomplete L10n', 'Not Updated',
-                        '%s/%s' % (doc.parent.slug, request.LANGUAGE_CODE)])
+                        '{0!s}/{1!s}'.format(doc.parent.slug, request.LANGUAGE_CODE)])
 
     if document_slug in COLLAPSIBLE_DOCUMENTS.get(request.LANGUAGE_CODE, []):
         document_css_class = 'collapsible'
@@ -171,10 +171,10 @@ def document(request, document_slug, template=None, document=None):
         document_css_class = ''
 
     if request.MOBILE and 'minimal' in request.GET:
-        template = '%sdocument-minimal.html' % template
+        template = '{0!s}document-minimal.html'.format(template)
         minimal = True
     else:
-        template = '%sdocument.html' % template
+        template = '{0!s}document.html'.format(template)
         minimal = False
 
     # Build a set of breadcrumbs, ending with the document's title, and
@@ -294,7 +294,7 @@ def _document_lock_check(document_id):
         return redis.get(key)
     except RedisError as e:
         statsd.incr('redis.errror')
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
         return None
 
 
@@ -312,7 +312,7 @@ def _document_lock_steal(document_id, user_name, expire_time=60 * 15):
         return it_worked
     except RedisError as e:
         statsd.incr('redis.errror')
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
         return False
 
 
@@ -337,7 +337,7 @@ def _document_lock_clear(document_id, user_name):
             return False
     except RedisError as e:
         statsd.incr('redis.errror')
-        log.error('Redis error: %s' % e)
+        log.error('Redis error: {0!s}'.format(e))
         return False
 
 
@@ -1216,8 +1216,7 @@ def delete_revision(request, document_slug, revision_id):
     if only_revision:
         return HttpResponseBadRequest()
 
-    log.warning('User %s is deleting revision with id=%s' %
-                (request.user, revision.id))
+    log.warning('User {0!s} is deleting revision with id={1!s}'.format(request.user, revision.id))
     revision.delete()
     return HttpResponseRedirect(reverse('wiki.document_revisions',
                                         args=[document.slug]))
@@ -1264,8 +1263,7 @@ def delete_document(request, document_slug):
             'document': document})
 
     # Handle confirm delete form POST
-    log.warning('User %s is deleting document: %s (id=%s)' %
-                (request.user, document.title, document.id))
+    log.warning('User {0!s} is deleting document: {1!s} (id={2!s})'.format(request.user, document.title, document.id))
     document.delete()
 
     return render(request, 'wiki/confirm_document_delete.html', {

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -89,8 +89,7 @@ class RadioInputWithHelpText(forms.widgets.RadioInput):
 
     def __unicode__(self):
         label = super(RadioInputWithHelpText, self).__unicode__()
-        return mark_safe('%s<div class="help-text">%s</div>' %
-                         (label, self.choice_help))
+        return mark_safe('{0!s}<div class="help-text">{1!s}</div>'.format(label, self.choice_help))
 
 
 class RadioFieldRendererWithHelpText(forms.widgets.RadioFieldRenderer):

--- a/migrations/159-topics-migration.py
+++ b/migrations/159-topics-migration.py
@@ -59,7 +59,7 @@ def run():
         try:
             destination_tag = Tag.objects.get(slug=tags_to_migrate[tag.slug])
         except Tag.DoesNotExist:
-            print 'Skipped tag %s' % tag
+            print 'Skipped tag {0!s}'.format(tag)
             continue
 
         # Get or create the topic.
@@ -70,12 +70,12 @@ def run():
             visible=True)
 
         if created:
-            print 'Created new topic "%s"' % smart_str(topic.slug)
+            print 'Created new topic "{0!s}"'.format(smart_str(topic.slug))
 
         # Assign the topic to all the documents tagged with tag.
         for doc in Document.objects.filter(tags__slug=tag.slug):
             doc.topics.add(topic)
-            print 'Added topic "%s" to document "%s"' % (
+            print 'Added topic "{0!s}" to document "{1!s}"'.format(
                 smart_str(topic.slug), smart_str(doc.title))
 
     print 'Done!'

--- a/migrations/160-products-migration.py
+++ b/migrations/160-products-migration.py
@@ -20,7 +20,7 @@ tags_to_migrate = {
 
 
 def assert_equals(a, b):
-    assert a == b, '%s != %s' % (a, b)
+    assert a == b, '{0!s} != {1!s}'.format(a, b)
 
 
 def run():
@@ -39,8 +39,8 @@ def run():
 
                 doc.products.add(product)
 
-                print 'Added product "%s" to document "%s"' % (
+                print 'Added product "{0!s}" to document "{1!s}"'.format(
                     smart_str(product.slug), smart_str(doc.title))
                 total_affected += 1
 
-    print 'Done! (%d)' % total_affected
+    print 'Done! ({0:d})'.format(total_affected)

--- a/migrations/174-remove-tags-from-documents.py
+++ b/migrations/174-remove-tags-from-documents.py
@@ -11,6 +11,6 @@ def run():
     # Get all instances of tags that point at a Document
     tags = TaggedItem.objects.filter(content_type=content_type)
 
-    print 'Deleting %d tags.' % tags.count()
+    print 'Deleting {0:d} tags.'.format(tags.count())
     tags.delete()
     print 'Done!'

--- a/migrations/194-questions-product-migration.py
+++ b/migrations/194-questions-product-migration.py
@@ -12,7 +12,7 @@ tags_to_migrate = {
 
 
 def assert_equals(a, b):
-    assert a == b, '%s != %s' % (a, b)
+    assert a == b, '{0!s} != {1!s}'.format(a, b)
 
 
 def run():
@@ -31,13 +31,13 @@ def run():
             n = 5000
             qs = Question.objects.filter(tags__slug=tag.slug)
             count = qs.count()
-            print '%s %s questions to work on...' % (count, product_slug)
+            print '{0!s} {1!s} questions to work on...'.format(count, product_slug)
             for i in range(0, count, n):
                 for question in qs[i:i + n]:
                     question.products.add(product)
 
-                    print 'Added product "%s" to question "%s"' % (
+                    print 'Added product "{0!s}" to question "{1!s}"'.format(
                         smart_str(product.slug), smart_str(question.title))
                     total_affected += 1
 
-    print 'Done! (%d)' % total_affected
+    print 'Done! ({0:d})'.format(total_affected)

--- a/migrations/198-set-unusable-password.py
+++ b/migrations/198-set-unusable-password.py
@@ -8,4 +8,4 @@ def run():
     if not num:
         print 'There is nothing to update.'
         return
-    print 'Done! Updated %d passwords.' % num
+    print 'Done! Updated {0:d} passwords.'.format(num)

--- a/migrations/218-create-new-topics.py
+++ b/migrations/218-create-new-topics.py
@@ -24,7 +24,7 @@ def run():
         # to the documents.
         for product in products:
             print '=========================================================='
-            print '[%s] %s' % (product, old_topic.title)
+            print '[{0!s}] {1!s}'.format(product, old_topic.title)
             print '=========================================================='
             try:
                 topic = Topic.objects.get(

--- a/migrations/226-retopic-questions.py
+++ b/migrations/226-retopic-questions.py
@@ -20,8 +20,7 @@ def run():
                     }
                 )
                 if created:
-                    print ('Created missing topic %s/%s'
-                           % (product_slug, topic_desc['topic']))
+                    print ('Created missing topic {0!s}/{1!s}'.format(product_slug, topic_desc['topic']))
 
     # Assign all the right new topics to the right old topics.
     for product in Product.objects.all():
@@ -29,6 +28,6 @@ def run():
         for topic in topics:
             questions = Question.objects.filter(products=product,
                                                 old_topics__slug=topic.slug)
-            print '%s / %s (%d questions)' % (product.title, topic.title, len(questions))
+            print '{0!s} / {1!s} ({2:d} questions)'.format(product.title, topic.title, len(questions))
             for q in questions:
                 q.topics.add(topic)

--- a/migrations/models.py
+++ b/migrations/models.py
@@ -28,7 +28,7 @@ class Topic(ModelBase):
         ordering = ['display_order']
 
     def __unicode__(self):
-        return u'%s' % self.title
+        return u'{0!s}'.format(self.title)
 
     @property
     def image_url(self):

--- a/scripts/crontab/gen-crons.py
+++ b/scripts/crontab/gen-crons.py
@@ -24,12 +24,12 @@ def main():
         parser.error("-k must be defined")
 
     ctx = {
-        'django': 'cd %s; source virtualenv/bin/activate; %s -W ignore::DeprecationWarning manage.py' % (
+        'django': 'cd {0!s}; source virtualenv/bin/activate; {1!s} -W ignore::DeprecationWarning manage.py'.format(
             opts.kitsune, opts.python),
-        'scripts': 'cd %s; source virtualenv/bin/activate; %s' % (
+        'scripts': 'cd {0!s}; source virtualenv/bin/activate; {1!s}'.format(
             opts.kitsune, opts.python),
     }
-    ctx['cron'] = '%s cron' % ctx['django']
+    ctx['cron'] = '{0!s} cron'.format(ctx['django'])
     # Source the venv, don't mess with manage.py
     ctx['rscripts'] = ctx['scripts']
 
@@ -38,7 +38,7 @@ def main():
             if k == 'rscripts':
                 # rscripts get to run as whatever user is specified in crontab.tpl
                 continue
-            ctx[k] = '%s %s' % (opts.user, v)
+            ctx[k] = '{0!s} {1!s}'.format(opts.user, v)
 
     # Needs to stay below the opts.user injection.
     ctx['python'] = opts.python

--- a/scripts/in_review.py
+++ b/scripts/in_review.py
@@ -51,12 +51,12 @@ def fetch_bugs(params):
 
 
 def fetch_bug_history(bugid):
-    url = BUGZILLA_API_URL + ('/bug/%d/history' % bugid)
+    url = BUGZILLA_API_URL + ('/bug/{0:d}/history'.format(bugid))
     return fetch(url)
 
 
 def fetch_bug_comments(bugid):
-    url = BUGZILLA_API_URL + ('/bug/%d/comment' % bugid)
+    url = BUGZILLA_API_URL + ('/bug/{0:d}/comment'.format(bugid))
     return fetch(url)
 
 
@@ -86,12 +86,12 @@ def print_bugzilla_stats(from_date, to_date):
         creators[creator] = creators.get(creator, 0) + 1
         all_people.add(creator)
 
-    print 'Bugs created: %s' % creation_count
-    print 'Creators: %s' % len(creators)
+    print 'Bugs created: {0!s}'.format(creation_count)
+    print 'Creators: {0!s}'.format(len(creators))
     print ''
     creators = sorted(creators.items(), reverse=True, key=lambda item: item[1])
     for person, count in creators:
-        print ' %34s : %s' % (person[:30].encode('utf-8'), count)
+        print ' {0:34!s} : {1!s}'.format(person[:30].encode('utf-8'), count)
     print ''
 
     # ------------------------------------------------
@@ -171,46 +171,46 @@ def print_bugzilla_stats(from_date, to_date):
             commenters[commenter] = commenters.get(commenter, 0) + 1
             all_people.add(commenter)
 
-    print 'Bugs resolved: %s' % resolved_count
+    print 'Bugs resolved: {0!s}'.format(resolved_count)
     print ''
     for resolution, count in resolved_map.items():
-        print ' %34s : %s' % (resolution, count)
+        print ' {0:34!s} : {1!s}'.format(resolution, count)
 
     print ''
     for title, count in [('Tracebacks', len(traceback_bugs)),
                          ('Research', len(research_bugs)),
                          ('Tracker', len(tracker_bugs))]:
-        print ' %34s : %s' % (title, count)
+        print ' {0:34!s} : {1!s}'.format(title, count)
 
     print ''
-    print 'Research bugs: %s' % len(research_bugs)
+    print 'Research bugs: {0!s}'.format(len(research_bugs))
     print ''
     for bug in research_bugs:
-        print wrap('%s: %s' % (bug['id'], bug['summary']),
+        print wrap('{0!s}: {1!s}'.format(bug['id'], bug['summary']),
                    subsequent='        ')
 
     print ''
-    print 'Tracker bugs: %s' % len(tracker_bugs)
+    print 'Tracker bugs: {0!s}'.format(len(tracker_bugs))
     print ''
     for bug in tracker_bugs:
-        print wrap('%s: %s' % (bug['id'], bug['summary']),
+        print wrap('{0!s}: {1!s}'.format(bug['id'], bug['summary']),
                    subsequent='        ')
 
     print ''
-    print 'Resolvers: %s' % len(resolvers)
+    print 'Resolvers: {0!s}'.format(len(resolvers))
     print ''
     resolvers = sorted(resolvers.items(), reverse=True,
                        key=lambda item: item[1])
     for person, count in resolvers:
-        print ' %34s : %s' % (person[:30].encode('utf-8'), count)
+        print ' {0:34!s} : {1!s}'.format(person[:30].encode('utf-8'), count)
 
     print ''
-    print 'Commenters: %s' % len(commenters)
+    print 'Commenters: {0!s}'.format(len(commenters))
     print ''
     commenters = sorted(commenters.items(), reverse=True,
                         key=lambda item: item[1])
     for person, count in commenters:
-        print ' %34s : %s' % (person[:30].encode('utf-8'), count)
+        print ' {0:34!s} : {1!s}'.format(person[:30].encode('utf-8'), count)
 
 
 def git(*args):
@@ -274,7 +274,7 @@ def print_git_stats(from_date, to_date):
     committers = sorted(
         committers.items(), key=lambda item: item[1], reverse=True)
     for person, count in committers:
-        print '  %20s : %5s  (+%s, -%s, files %s)' % (
+        print '  {0:20!s} : {1:5!s}  (+{2!s}, -{3!s}, files {4!s})'.format(
             person.encode('utf-8'), count,
             changes[person][0], changes[person][1], changes[person][2])
         all_people.add(person)
@@ -294,7 +294,7 @@ def print_all_people():
     people = sorted(all_people, key=lambda a: a.lower())
 
     for person in people:
-        print '    %s' % person.encode('utf-8')
+        print '    {0!s}'.format(person.encode('utf-8'))
 
 
 def print_header(text):
@@ -322,7 +322,7 @@ def main(argv):
         from_date = datetime.date(year, 1, 1)
         to_date = datetime.date(year, 12, 31)
 
-        print_header('Year %s (%s -> %s)' % (year, from_date, to_date))
+        print_header('Year {0!s} ({1!s} -> {2!s})'.format(year, from_date, to_date))
 
     else:
         quarter = int(argv[1])
@@ -333,7 +333,7 @@ def main(argv):
         to_date = datetime.date(
             year, quarter_dates[1][0], quarter_dates[1][1])
 
-        print_header('Quarter %sq%s (%s -> %s)' % (
+        print_header('Quarter {0!s}q{1!s} ({2!s} -> {3!s})'.format(
             year, quarter, from_date, to_date))
 
     # Add 1 day because we do less-than.

--- a/scripts/peep.py
+++ b/scripts/peep.py
@@ -135,7 +135,7 @@ class DownloadError(Exception):
         self.reason = str(exc)
 
     def __str__(self):
-        return 'Downloading %s failed: %s' % (self.link, self.reason)
+        return 'Downloading {0!s} failed: {1!s}'.format(self.link, self.reason)
 
 
 def encoded_hash(sha):
@@ -535,9 +535,9 @@ class DownloadedReq(object):
                         break
                     yield chunk
 
-            print('Downloading %s%s...' % (
+            print('Downloading {0!s}{1!s}...'.format(
                 self._req.req,
-                (' (%sK)' % (size / 1000)) if size > 1000 else ''))
+                (' ({0!s}K)'.format((size / 1000))) if size > 1000 else ''))
             progress_indicator = (DownloadProgressBar(max=size).iter if size
                                   else DownloadProgressSpinner().iter)
             with open(path, 'wb') as file:
@@ -607,8 +607,7 @@ class DownloadedReq(object):
                     "etc." % (self._req, link.url))
         else:
             raise UnsupportedRequirementError(
-                "%s: couldn't determine where to download this requirement from."
-                % (self._req,))
+                "{0!s}: couldn't determine where to download this requirement from.".format(self._req))
 
     def install(self):
         """Install the package I represent, without dependencies.
@@ -691,7 +690,7 @@ class MalformedReq(DownloadedReq):
         return 'The following requirements could not be processed:\n'
 
     def error(self):
-        return '* Unable to determine package name from URL %s; add #egg=' % self._url()
+        return '* Unable to determine package name from URL {0!s}; add #egg='.format(self._url())
 
 
 class MissingReq(DownloadedReq):
@@ -709,8 +708,8 @@ class MissingReq(DownloadedReq):
             # MalformedRequest.
             line = self._url()
         else:
-            line = '%s==%s' % (self._name(), self._version())
-        return '# sha256: %s\n%s\n' % (self._actual_hash(), line)
+            line = '{0!s}=={1!s}'.format(self._name(), self._version())
+        return '# sha256: {0!s}\n{1!s}\n'.format(self._actual_hash(), line)
 
 
 class MismatchedReq(DownloadedReq):
@@ -722,11 +721,11 @@ class MismatchedReq(DownloadedReq):
                 "freak out, because someone has tampered with the packages.\n\n")
 
     def error(self):
-        preamble = '    %s: expected' % self._project_name()
+        preamble = '    {0!s}: expected'.format(self._project_name())
         if len(self._expected_hashes()) > 1:
             preamble += ' one of'
         padding = '\n' + ' ' * (len(preamble) + 1)
-        return '%s %s\n%s got %s' % (preamble,
+        return '{0!s} {1!s}\n{2!s} got {3!s}'.format(preamble,
                                      padding.join(self._expected_hashes()),
                                      ' ' * (len(preamble) - 4),
                                      self._actual_hash())
@@ -746,7 +745,7 @@ class SatisfiedReq(DownloadedReq):
                 "safe. If not, uninstall them, then re-attempt your install with peep.\n")
 
     def error(self):
-        return '   %s' % (self._req,)
+        return '   {0!s}'.format(self._req)
 
 
 class InstallableReq(DownloadedReq):

--- a/scripts/sprint_report.py
+++ b/scripts/sprint_report.py
@@ -239,8 +239,8 @@ def sprint_timeline(bugs, sprint):
 
     timeline.sort(key=lambda item: item[0])
     for mem in timeline:
-        print '%s: %s: %s' % (mem[0], mem[1], mem[2])
-        print '    %s -> %s' % (mem[3] if mem[3] else 'unassigned', mem[4])
+        print '{0!s}: {1!s}: {2!s}'.format(mem[0], mem[1], mem[2])
+        print '    {0!s} -> {1!s}'.format(mem[3] if mem[3] else 'unassigned', mem[4])
         print wrap(mem[5])
         print ''
 
@@ -264,7 +264,7 @@ def main(argv):
     print HEADER
 
     print ''
-    print 'Working on %s' % sprint
+    print 'Working on {0!s}'.format(sprint)
     print ''
 
     bugzilla = BugzillaAPI(

--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -24,7 +24,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'kitsune.settings_local'
 def update_code(ctx, tag):
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("git fetch")
-        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git checkout -f {0!s}".format(tag))
         ctx.local("find -name '*.pyc' -delete")
 
 
@@ -63,9 +63,8 @@ def db_migrations(ctx):
 @task
 def install_cron(ctx):
     with ctx.lcd(settings.SRC_DIR):
-        ctx.local("python2.7 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
-                  (settings.WWW_DIR, settings.CRON_NAME))
-        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+        ctx.local("python2.7 ./scripts/crontab/gen-crons.py -k {0!s} -u apache > /etc/cron.d/.{1!s}".format(settings.WWW_DIR, settings.CRON_NAME))
+        ctx.local("mv /etc/cron.d/.{0!s} /etc/cron.d/{1!s}".format(settings.CRON_NAME, settings.CRON_NAME))
 
 
 @task
@@ -88,7 +87,7 @@ def deploy_app(ctx):
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def update_celery(ctx):
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
-    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+    ctx.remote('/sbin/service {0!s} restart'.format(settings.CELERY_SERVICE))
 
 
 @task

--- a/scripts/year_in_review.py
+++ b/scripts/year_in_review.py
@@ -205,7 +205,7 @@ def bugzilla_stats(year):
     # -------------------------------------------
     bugs = bugzilla.get_bugs(
         product=PRODUCTS,
-        creation_time='%s-01-01' % year,
+        creation_time='{0!s}-01-01'.format(year),
         include_fields=['id', 'creator', 'creation_time'],
         history=False,
         comments=False)
@@ -235,7 +235,7 @@ def bugzilla_stats(year):
     # -------------------------------------------
     bugs = bugzilla.get_bugs(
         product=PRODUCTS,
-        last_change_time='%s-01-01' % year,
+        last_change_time='{0!s}-01-01'.format(year),
         include_fields=['id', 'summary', 'assigned_to', 'last_change_time', 'resolution'],
         status=['RESOLVED', 'VERIFIED', 'CLOSED'],
         history=True,
@@ -342,8 +342,8 @@ def git_stats(year):
     # Get the shas for all the commits we're going to look at.
     all_commits = subprocess.check_output([
         'git', 'log',
-        '--after=%s-01-01' % year,
-        '--before=%s-01-01' % (int(year) + 1),
+        '--after={0!s}-01-01'.format(year),
+        '--before={0!s}-01-01'.format((int(year) + 1)),
         '--format=%H'
     ])
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:kitsune?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:kitsune?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
